### PR TITLE
feat: modern JSON Schema support — $defs, dependentSchemas, dependentRequired (C37)

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -7,14 +7,14 @@ on:
       - 'LICENSE'
       - 'README*'
       - 'CODE_OF_CONDUCT*'
-    branches: [main]
+    branches: [main, feature/json-schema-rewrite-clean]
   pull_request:
     paths-ignore:
       - '.gitignore'
       - 'LICENSE'
       - 'README*'
       - 'CODE_OF_CONDUCT*'
-    branches: [main]
+    branches: [main, feature/json-schema-rewrite-clean]
 
 jobs:
   build-verify:

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/CompoundSchemaDiffVisitor.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/CompoundSchemaDiffVisitor.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.apitomy.datamodels.jsonschema.convert.CompoundSchemaConverter;
 import io.apitomy.datamodels.models.ModelType;
 import io.apitomy.datamodels.models.jsonschema.BooleanFullSchemaFullSchemaListUnion;
-import io.apitomy.datamodels.models.jsonschema.Dependency;
 import io.apitomy.datamodels.models.jsonschema.JFullSchema;
 import io.apitomy.datamodels.models.jsonschema.JsonSchema;
 import io.apitomy.datamodels.models.jsonschema.compound.JCFullSchema;
@@ -19,6 +18,7 @@ import java.math.BigDecimal;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static io.apitomy.datamodels.jsonschema.compat.DiffType.*;
 import static io.apitomy.datamodels.jsonschema.compat.DiffUtil.*;
@@ -233,7 +233,18 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     public boolean visitFullSchemaPatternProperty(JsonSchema original, JsonSchema updated) { return false; }
 
     @Override
-    public boolean visitFullSchemaDependency(Dependency original, Dependency updated) { return false; }
+    public boolean visitFullSchemaDependentSchema(JsonSchema original, JsonSchema updated) {
+        if (original != null && updated != null
+                && original.isFullSchema() && updated.isFullSchema()) {
+            var subCtx = ctx.sub("dependentSchemas");
+            if (!isSchemaCompatible(subCtx, original.asFullSchema(),
+                    updated.asFullSchema(), true)) {
+                subCtx.addDifference(OBJECT_TYPE_SCHEMA_DEPENDENCIES_CHANGED,
+                        original, updated);
+            }
+        }
+        return false;
+    }
 
     @Override
     public boolean visitFullSchemaAllOfItem(JsonSchema original, JsonSchema updated) { return false; }
@@ -755,11 +766,31 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
         return false;
     }
 
+    // dependencies is always empty after conversion — d4-d7 entries are split
+    // into dependentSchemas/dependentRequired by the converters.
+
     @Override
-    public void diffFullSchemaDependencies(Map<String, Dependency> original,
-                                           Map<String, Dependency> updated,
-                                           CollectionDiff<DefaultPairingKey, Dependency> diff) {
-        // Suppress auto-recursion for matched dependencies
+    public void diffFullSchemaDependentSchemas(Map<String, JsonSchema> original,
+                                                Map<String, JsonSchema> updated,
+                                                CollectionDiff<DefaultPairingKey, JsonSchema> diff) {
+        if (original == null && updated == null) return;
+
+        var origKeys = original != null
+                ? new HashSet<>(original.keySet()) : new HashSet<String>();
+        var updKeys = updated != null
+                ? new HashSet<>(updated.keySet()) : new HashSet<String>();
+
+        diffSetChanged(ctx, origKeys, updKeys,
+                OBJECT_TYPE_PROPERTY_DEPENDENCIES_KEYS_ADDED,
+                OBJECT_TYPE_PROPERTY_DEPENDENCIES_KEYS_REMOVED,
+                OBJECT_TYPE_PROPERTY_DEPENDENCIES_KEYS_CHANGED,
+                OBJECT_TYPE_PROPERTY_DEPENDENCIES_KEYS_MEMBER_ADDED,
+                OBJECT_TYPE_PROPERTY_DEPENDENCIES_KEYS_MEMBER_REMOVED);
+    }
+
+    @Override
+    public void diffFullSchemaDependentRequired(Map<String, JsonNode> original,
+                                                 Map<String, JsonNode> updated) {
         if (original == null && updated == null) return;
 
         var origKeys = original != null
@@ -778,40 +809,43 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
             var commonKeys = new HashSet<>(origKeys);
             commonKeys.retainAll(updKeys);
             for (var key : commonKeys) {
-                var origValue = original.get(key);
-                var updValue = updated.get(key);
-                if (origValue.isStringList() && updValue.isStringList()) {
-                    var origSet = new HashSet<>(origValue.asStringList());
-                    var updSet = new HashSet<>(updValue.asStringList());
-                    for (var v : origSet) {
-                        if (!updSet.contains(v)) {
-                            ctx.addDifference(
-                                    OBJECT_TYPE_PROPERTY_DEPENDENCIES_VALUE_MEMBER_REMOVED,
-                                    v, null);
-                        }
-                    }
-                    for (var v : updSet) {
-                        if (!origSet.contains(v)) {
-                            ctx.addDifference(
-                                    OBJECT_TYPE_PROPERTY_DEPENDENCIES_VALUE_MEMBER_ADDED,
-                                    null, v);
-                        }
-                    }
-                    if (!origSet.equals(updSet)) {
+                var origArray = original.get(key);
+                var updArray = updated.get(key);
+                var origSet = jsonArrayToStringSet(origArray);
+                var updSet = jsonArrayToStringSet(updArray);
+                for (var v : origSet) {
+                    if (!updSet.contains(v)) {
                         ctx.addDifference(
-                                OBJECT_TYPE_PROPERTY_DEPENDENCIES_VALUE_MEMBER_CHANGED,
-                                origValue, updValue);
+                                OBJECT_TYPE_PROPERTY_DEPENDENCIES_VALUE_MEMBER_REMOVED,
+                                v, null);
                     }
-                } else if (origValue.isFullSchema() && updValue.isFullSchema()) {
-                    var subCtx = ctx.sub("dependencies/" + key);
-                    if (!isSchemaCompatible(subCtx, origValue.asFullSchema(),
-                            updValue.asFullSchema(), true)) {
-                        subCtx.addDifference(OBJECT_TYPE_SCHEMA_DEPENDENCIES_CHANGED,
-                                origValue, updValue);
+                }
+                for (var v : updSet) {
+                    if (!origSet.contains(v)) {
+                        ctx.addDifference(
+                                OBJECT_TYPE_PROPERTY_DEPENDENCIES_VALUE_MEMBER_ADDED,
+                                null, v);
                     }
+                }
+                if (!origSet.equals(updSet)) {
+                    ctx.addDifference(
+                            OBJECT_TYPE_PROPERTY_DEPENDENCIES_VALUE_MEMBER_CHANGED,
+                            origArray, updArray);
                 }
             }
         }
+    }
+
+    private static Set<String> jsonArrayToStringSet(JsonNode arrayNode) {
+        var set = new HashSet<String>();
+        if (arrayNode != null && arrayNode.isArray()) {
+            for (var element : arrayNode) {
+                if (element.isTextual()) {
+                    set.add(element.asText());
+                }
+            }
+        }
+        return set;
     }
 
     // -----------------------------------------------------------------------

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/JsonSchemaCompatibilityChecker.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/JsonSchemaCompatibilityChecker.java
@@ -135,10 +135,6 @@ public final class JsonSchemaCompatibilityChecker {
         var originalCompound = toCompoundFullSchema(originalParsed, originalModelType);
         var updatedCompound = toCompoundFullSchema(updatedParsed, updatedModelType);
 
-        // TODO: Modern version support — flag for now, remove when diff classes handle all keywords
-        flagModernVersions(ctx, originalModelType);
-        flagModernVersions(ctx, updatedModelType);
-
         CompoundSchemaDiffVisitor.diffSchemas(ctx, originalCompound, updatedCompound);
         return ctx;
     }
@@ -149,12 +145,6 @@ public final class JsonSchemaCompatibilityChecker {
             return (JFullSchema) compound;
         }
         throw new IllegalArgumentException("Failed to convert schema to compound type");
-    }
-
-    private static void flagModernVersions(DiffContext ctx, ModelType modelType) {
-        if (modelType == ModelType.JM201909 || modelType == ModelType.JM202012) {
-            ctx.addUnsupported("JSON Schema %s (modern version support not yet implemented)".formatted(modelType));
-        }
     }
 
     private static JFullSchema parseSchema(String schemaJson) {

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/convert/CompoundSchemaConverter.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/convert/CompoundSchemaConverter.java
@@ -1,13 +1,20 @@
 package io.apitomy.datamodels.jsonschema.convert;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.apitomy.datamodels.models.Any;
 import io.apitomy.datamodels.models.ModelType;
+import io.apitomy.datamodels.models.jsonschema.Dependency;
 import io.apitomy.datamodels.models.jsonschema.JsonSchema;
+import io.apitomy.datamodels.models.jsonschema.compound.JCFullSchema;
 import io.apitomy.datamodels.models.jsonschema.draft.draft4.visitors.JD4ToJCConversionTraverser;
 import io.apitomy.datamodels.models.jsonschema.draft.draft6.visitors.JD6ToJCConversionTraverser;
 import io.apitomy.datamodels.models.jsonschema.draft.draft7.visitors.JD7ToJCConversionTraverser;
 import io.apitomy.datamodels.models.jsonschema.modern.v201909.visitors.JM201909ToJCConversionTraverser;
 import io.apitomy.datamodels.models.jsonschema.modern.v202012.visitors.JM202012ToJCConversionTraverser;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * Converts any JSON Schema version to the compound schema type.
@@ -40,5 +47,30 @@ public class CompoundSchemaConverter {
                 return source;
         }
         return (JsonSchema) result;
+    }
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * Splits a d4-d7 {@code dependencies} map into {@code dependentSchemas}
+     * and {@code dependentRequired} on the compound target.
+     */
+    static void splitDependencies(Map<String, Dependency> value, JCFullSchema target) {
+        if (value == null) return;
+        Map<String, JsonNode> requiredMap = null;
+        for (Map.Entry<String, Dependency> entry : value.entrySet()) {
+            var dep = entry.getValue();
+            if (dep.isFullSchema()) {
+                target.addDependentSchema(entry.getKey(), (JsonSchema) dep.asFullSchema());
+            } else if (dep.isStringList()) {
+                if (requiredMap == null) {
+                    requiredMap = new LinkedHashMap<>();
+                }
+                requiredMap.put(entry.getKey(), MAPPER.valueToTree(dep.asStringList()));
+            }
+        }
+        if (requiredMap != null) {
+            target.setDependentRequired(requiredMap);
+        }
     }
 }

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/convert/JD4ToCompoundConverter.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/convert/JD4ToCompoundConverter.java
@@ -1,9 +1,12 @@
 package io.apitomy.datamodels.jsonschema.convert;
 
+import io.apitomy.datamodels.models.jsonschema.Dependency;
 import io.apitomy.datamodels.models.jsonschema.compound.JCFullSchema;
 import io.apitomy.datamodels.models.jsonschema.compound.JCRangeValue;
 import io.apitomy.datamodels.models.jsonschema.compound.JCRangeValueImpl;
 import io.apitomy.datamodels.models.jsonschema.draft.draft4.visitors.JD4ToJCConversionVisitor;
+
+import java.util.Map;
 
 /**
  * Converts Draft 4 schemas to the compound schema type.
@@ -41,6 +44,11 @@ public class JD4ToCompoundConverter extends JD4ToJCConversionVisitor {
         if (Boolean.TRUE.equals(value) && target.getMaximum() != null) {
             target.getMaximum().setExclusive(true);
         }
+    }
+
+    @Override
+    public void convertFullSchemaDependencies(Map<String, Dependency> value, JCFullSchema target) {
+        CompoundSchemaConverter.splitDependencies(value, target);
     }
 
     private static JCRangeValue rangeValue(Number value, boolean exclusive) {

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/convert/JD6ToCompoundConverter.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/convert/JD6ToCompoundConverter.java
@@ -1,11 +1,13 @@
 package io.apitomy.datamodels.jsonschema.convert;
 
+import io.apitomy.datamodels.models.jsonschema.Dependency;
 import io.apitomy.datamodels.models.jsonschema.compound.JCFullSchema;
 import io.apitomy.datamodels.models.jsonschema.compound.JCRangeValue;
 import io.apitomy.datamodels.models.jsonschema.compound.JCRangeValueImpl;
 import io.apitomy.datamodels.models.jsonschema.draft.draft6.visitors.JD6ToJCConversionVisitor;
 
 import java.math.BigDecimal;
+import java.util.Map;
 
 /**
  * Converts Draft 6 schemas to the compound schema type.
@@ -46,6 +48,11 @@ public class JD6ToCompoundConverter extends JD6ToJCConversionVisitor {
                 target.setMaximum(rangeValue(value, true));
             }
         }
+    }
+
+    @Override
+    public void convertFullSchemaDependencies(Map<String, Dependency> value, JCFullSchema target) {
+        CompoundSchemaConverter.splitDependencies(value, target);
     }
 
     /**

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/convert/JD7ToCompoundConverter.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/convert/JD7ToCompoundConverter.java
@@ -1,11 +1,13 @@
 package io.apitomy.datamodels.jsonschema.convert;
 
+import io.apitomy.datamodels.models.jsonschema.Dependency;
 import io.apitomy.datamodels.models.jsonschema.compound.JCFullSchema;
 import io.apitomy.datamodels.models.jsonschema.compound.JCRangeValue;
 import io.apitomy.datamodels.models.jsonschema.compound.JCRangeValueImpl;
 import io.apitomy.datamodels.models.jsonschema.draft.draft7.visitors.JD7ToJCConversionVisitor;
 
 import java.math.BigDecimal;
+import java.util.Map;
 
 /**
  * Converts Draft 7 schemas to the compound schema type.
@@ -46,6 +48,11 @@ public class JD7ToCompoundConverter extends JD7ToJCConversionVisitor {
                 target.setMaximum(rangeValue(value, true));
             }
         }
+    }
+
+    @Override
+    public void convertFullSchemaDependencies(Map<String, Dependency> value, JCFullSchema target) {
+        CompoundSchemaConverter.splitDependencies(value, target);
     }
 
     private static boolean isTighterMinimum(Number newValue, boolean newExclusive, JCRangeValue existing) {

--- a/data-models/src/test/resources/io/apitomy/datamodels/jsonschema/compat/compatibility-test-data.json
+++ b/data-models/src/test/resources/io/apitomy/datamodels/jsonschema/compat/compatibility-test-data.json
@@ -3827,6 +3827,176 @@
         "backward": { "compatible": true },
         "forward": { "compatible": true }
       }
+    },
+    {
+      "enabled": true,
+      "id": "Modern: $defs basic compatibility",
+      "compatibility": "both",
+      "original": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "$defs": {
+          "Address": {
+            "type": "object",
+            "properties": { "street": { "type": "string" } }
+          }
+        },
+        "properties": { "home": { "$ref": "#/$defs/Address" } }
+      },
+      "updated": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "$defs": {
+          "Address": {
+            "type": "object",
+            "properties": { "street": { "type": "string" } }
+          }
+        },
+        "properties": { "home": { "$ref": "#/$defs/Address" } }
+      }
+    },
+    {
+      "enabled": true,
+      "id": "Modern: dependentSchemas add dependency",
+      "compatibility": "backward",
+      "original": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "properties": { "name": { "type": "string" }, "address": { "type": "string" } },
+        "dependentSchemas": {
+          "address": {
+            "properties": { "city": { "type": "string" } }
+          }
+        }
+      },
+      "updated": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "properties": { "name": { "type": "string" }, "address": { "type": "string" } }
+      }
+    },
+    {
+      "enabled": true,
+      "id": "Modern: dependentRequired add member",
+      "compatibility": "backward",
+      "original": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "properties": { "name": { "type": "string" }, "address": { "type": "string" }, "city": { "type": "string" } },
+        "dependentRequired": {
+          "address": ["city"]
+        }
+      },
+      "updated": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "properties": { "name": { "type": "string" }, "address": { "type": "string" }, "city": { "type": "string" } }
+      }
+    },
+    {
+      "enabled": true,
+      "id": "Modern: dependentRequired added is not backward compatible",
+      "original": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "properties": { "name": { "type": "string" }, "address": { "type": "string" } },
+        "required": ["name"]
+      },
+      "updated": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "properties": { "name": { "type": "string" }, "address": { "type": "string" } },
+        "required": ["name"],
+        "dependentRequired": {
+          "address": ["name"]
+        }
+      },
+      "expected": {
+        "backward": { "compatible": false },
+        "forward": { "compatible": true }
+      }
+    },
+    {
+      "enabled": true,
+      "id": "Cross-version: d7 dependencies vs 2019-09 dependentSchemas",
+      "config": { "allowCrossVersionChecking": true },
+      "compatibility": "both",
+      "original": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": { "name": { "type": "string" }, "address": { "type": "string" } },
+        "dependencies": {
+          "address": {
+            "properties": { "city": { "type": "string" } }
+          }
+        }
+      },
+      "updated": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "properties": { "name": { "type": "string" }, "address": { "type": "string" } },
+        "dependentSchemas": {
+          "address": {
+            "properties": { "city": { "type": "string" } }
+          }
+        }
+      }
+    },
+    {
+      "enabled": true,
+      "id": "Cross-version: d7 dependencies (string-array) vs 2019-09 dependentRequired",
+      "config": { "allowCrossVersionChecking": true },
+      "compatibility": "both",
+      "original": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": { "name": { "type": "string" }, "address": { "type": "string" }, "city": { "type": "string" } },
+        "dependencies": {
+          "address": ["city"]
+        }
+      },
+      "updated": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "properties": { "name": { "type": "string" }, "address": { "type": "string" }, "city": { "type": "string" } },
+        "dependentRequired": {
+          "address": ["city"]
+        }
+      }
+    },
+    {
+      "enabled": true,
+      "id": "Modern: 2019-09 basic schema compatibility",
+      "compatibility": "both",
+      "original": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "properties": { "name": { "type": "string" }, "age": { "type": "integer" } },
+        "required": ["name"]
+      },
+      "updated": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "properties": { "name": { "type": "string" }, "age": { "type": "integer" } },
+        "required": ["name"]
+      }
+    },
+    {
+      "enabled": true,
+      "id": "Modern: 2020-12 basic schema compatibility",
+      "compatibility": "both",
+      "original": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": { "name": { "type": "string" } },
+        "required": ["name"]
+      },
+      "updated": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "properties": { "name": { "type": "string" } },
+        "required": ["name"]
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Normalize d4-d7 `dependencies` into `dependentSchemas` + `dependentRequired` during compound conversion
- D4/D6/D7 converters split dependencies via `CompoundSchemaConverter.splitDependencies`
- `diffFullSchemaDependentSchemas`: key tracking + compatibility-aware schema comparison
- `diffFullSchemaDependentRequired`: key tracking + string-array set comparison
- `$defs`: handled by auto-recursion (same pattern as `definitions`)
- Remove `flagModernVersions` — 2019-09/2020-12 no longer flagged as unsupported
- 8 new test cases (modern keywords + cross-version d7↔2019-09)

## Context
C37 in #1042. First step of modern JSON Schema version support.

## Test plan
- [x] All 155 CC data-driven tests pass (147 existing + 8 new)
- [x] 8 dereferencer tests pass