### PR TITLE
feat: multi-valued type support + modern test data (C41, C41b)

### DIFF
--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/CompoundSchemaDiffVisitor.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/CompoundSchemaDiffVisitor.java
@@ -123,10 +123,38 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
             return false;
         }
 
+        var origTypeList = DiffUtil.getTypeList(original);
+        var updTypeList = DiffUtil.getTypeList(updated);
         var originalType = DiffUtil.getTypeString(original);
         var updatedType = DiffUtil.getTypeString(updated);
 
-        if (originalType != null && updatedType != null && !originalType.equals(updatedType)) {
+        if (origTypeList != null && updTypeList != null) {
+            var origSet = new HashSet<>(origTypeList);
+            var updSet = new HashSet<>(updTypeList);
+            // Normalize: integer is a subset of number
+            if (origSet.contains("integer") && updSet.contains("number")) {
+                origSet.remove("integer");
+                origSet.add("number");
+            }
+            if (updSet.contains("integer") && origSet.contains("number")) {
+                updSet.remove("integer");
+                updSet.add("number");
+            }
+            if (!origSet.equals(updSet)) {
+                var added = new HashSet<>(updSet);
+                added.removeAll(origSet);
+                var removed = new HashSet<>(origSet);
+                removed.removeAll(updSet);
+                if (!removed.isEmpty() && added.isEmpty()) {
+                    ctx.addDifference(SUBSCHEMA_TYPE_CHANGED, origTypeList, updTypeList);
+                } else if (removed.isEmpty() && !added.isEmpty()) {
+                    ctx.addDifference(SUBSCHEMA_TYPE_CHANGED_TO_EMPTY_OR_TRUE, origTypeList, updTypeList);
+                } else {
+                    ctx.addDifference(SUBSCHEMA_TYPE_CHANGED, origTypeList, updTypeList);
+                }
+                return false;
+            }
+        } else if (originalType != null && updatedType != null && !originalType.equals(updatedType)) {
             if ("integer".equals(originalType) && "number".equals(updatedType)) {
                 ctx.addDifference(SUBSCHEMA_TYPE_CHANGED_TO_EMPTY_OR_TRUE, originalType, updatedType);
             } else if (updatedType.isEmpty() || isEmptyOrTrueSchema(updated)) {
@@ -134,15 +162,12 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
             } else {
                 ctx.addDifference(SUBSCHEMA_TYPE_CHANGED, originalType, updatedType);
             }
-            return false; // type changed — no point comparing fields
-        }
-
-        if (originalType != null && updatedType == null) {
+            return false;
+        } else if (originalType != null && updatedType == null) {
             if (isEmptyOrTrueSchema(updated)) {
                 ctx.addDifference(SUBSCHEMA_TYPE_CHANGED_TO_EMPTY_OR_TRUE, originalType, "");
                 return false;
             }
-            // Check if updated uses composition (anyOf/oneOf) that includes the original type
             var updAnyOf = updated.getAnyOf();
             var updOneOf = updated.getOneOf();
             if (updAnyOf != null || updOneOf != null) {
@@ -162,23 +187,10 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
                     return false;
                 }
             }
-        }
-
-        if (originalType == null && updatedType != null) {
+        } else if (originalType == null && updatedType != null) {
             if (isEmptyOrTrueSchema(original)) {
                 ctx.addDifference(SUBSCHEMA_TYPE_CHANGED, "", updatedType);
                 return false;
-            }
-        }
-
-        // Multi-valued type check
-        var effectiveType = originalType != null ? originalType : updatedType;
-        if (effectiveType == null) {
-            var origTypeList = DiffUtil.getTypeList(original);
-            var updTypeList = DiffUtil.getTypeList(updated);
-            if ((origTypeList != null && origTypeList.size() > 1)
-                    || (updTypeList != null && updTypeList.size() > 1)) {
-                ctx.addUnsupported("Multi-valued type field (e.g. type: [\"string\", \"number\"])");
             }
         }
 

--- a/data-models/src/test/resources/io/apitomy/datamodels/jsonschema/compat/compatibility-test-data.json
+++ b/data-models/src/test/resources/io/apitomy/datamodels/jsonschema/compat/compatibility-test-data.json
@@ -4101,6 +4101,177 @@
         "type": "object",
         "properties": { "name": { "type": "string" } }
       }
+    },
+    {
+      "enabled": true,
+      "id": "Cross-version: d7 definitions vs 2019-09 $defs",
+      "config": { "allowCrossVersionChecking": true },
+      "compatibility": "both",
+      "original": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "definitions": {
+          "Name": { "type": "string", "minLength": 1 }
+        },
+        "properties": { "name": { "$ref": "#/definitions/Name" } }
+      },
+      "updated": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "$defs": {
+          "Name": { "type": "string", "minLength": 1 }
+        },
+        "properties": { "name": { "$ref": "#/$defs/Name" } }
+      }
+    },
+    {
+      "enabled": true,
+      "id": "Modern: $recursiveRef string comparison (same)",
+      "compatibility": "both",
+      "original": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$recursiveAnchor": true,
+        "type": "object",
+        "properties": {
+          "child": { "$recursiveRef": "#" }
+        }
+      },
+      "updated": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$recursiveAnchor": true,
+        "type": "object",
+        "properties": {
+          "child": { "$recursiveRef": "#" }
+        }
+      }
+    },
+    {
+      "enabled": true,
+      "id": "Modern: $dynamicRef string comparison (same)",
+      "compatibility": "both",
+      "original": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "$defs": {
+          "leaf": { "$dynamicAnchor": "leafType", "type": "string" }
+        },
+        "properties": {
+          "value": { "$dynamicRef": "#leafType" }
+        }
+      },
+      "updated": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "$defs": {
+          "leaf": { "$dynamicAnchor": "leafType", "type": "string" }
+        },
+        "properties": {
+          "value": { "$dynamicRef": "#leafType" }
+        }
+      }
+    },
+    {
+      "enabled": true,
+      "id": "Modern: 2019-09 if/then/else",
+      "compatibility": "both",
+      "original": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "properties": { "kind": { "type": "string" }, "value": {} },
+        "if": { "properties": { "kind": { "const": "number" } } },
+        "then": { "properties": { "value": { "type": "number" } } },
+        "else": { "properties": { "value": { "type": "string" } } }
+      },
+      "updated": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "properties": { "kind": { "type": "string" }, "value": {} },
+        "if": { "properties": { "kind": { "const": "number" } } },
+        "then": { "properties": { "value": { "type": "number" } } },
+        "else": { "properties": { "value": { "type": "string" } } }
+      }
+    },
+    {
+      "enabled": true,
+      "id": "Modern: dependentRequired member added within key",
+      "expected": {
+        "backward": { "compatible": false },
+        "forward": { "compatible": true }
+      },
+      "original": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "properties": { "billing": { "type": "string" }, "card": { "type": "string" }, "phone": { "type": "string" } },
+        "dependentRequired": {
+          "billing": ["card"]
+        }
+      },
+      "updated": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "properties": { "billing": { "type": "string" }, "card": { "type": "string" }, "phone": { "type": "string" } },
+        "dependentRequired": {
+          "billing": ["card", "phone"]
+        }
+      }
+    },
+    {
+      "enabled": true,
+      "id": "Modern: dependentRequired member removed within key",
+      "expected": {
+        "backward": { "compatible": true },
+        "forward": { "compatible": false }
+      },
+      "original": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "properties": { "billing": { "type": "string" }, "card": { "type": "string" }, "phone": { "type": "string" } },
+        "dependentRequired": {
+          "billing": ["card", "phone"]
+        }
+      },
+      "updated": {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "properties": { "billing": { "type": "string" }, "card": { "type": "string" }, "phone": { "type": "string" } },
+        "dependentRequired": {
+          "billing": ["card"]
+        }
+      }
+    },
+    {
+      "enabled": true,
+      "id": "Modern: 2020-12 composition (allOf/anyOf)",
+      "compatibility": "both",
+      "original": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "allOf": [
+          { "type": "object", "properties": { "name": { "type": "string" } } },
+          { "type": "object", "properties": { "age": { "type": "integer" } } }
+        ]
+      },
+      "updated": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "allOf": [
+          { "type": "object", "properties": { "name": { "type": "string" } } },
+          { "type": "object", "properties": { "age": { "type": "integer" } } }
+        ]
+      }
+    },
+    {
+      "enabled": true,
+      "id": "Modern: 2020-12 enum/const",
+      "compatibility": "both",
+      "original": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "string",
+        "enum": ["red", "green", "blue"]
+      },
+      "updated": {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "string",
+        "enum": ["red", "green", "blue"]
+      }
     }
   ]
 }

--- a/data-models/src/test/resources/io/apitomy/datamodels/jsonschema/compat/compatibility-test-data.json
+++ b/data-models/src/test/resources/io/apitomy/datamodels/jsonschema/compat/compatibility-test-data.json
@@ -4272,6 +4272,87 @@
         "type": "string",
         "enum": ["red", "green", "blue"]
       }
+    },
+    {
+      "enabled": true,
+      "id": "Multi-type: same types both compatible",
+      "compatibility": "both",
+      "original": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["string", "number"]
+      },
+      "updated": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["string", "number"]
+      }
+    },
+    {
+      "enabled": true,
+      "id": "Multi-type: type added is backward compatible",
+      "compatibility": "backward",
+      "original": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["string", "number"]
+      },
+      "updated": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["string", "number", "boolean"]
+      }
+    },
+    {
+      "enabled": true,
+      "id": "Multi-type: type removed is not backward compatible",
+      "expected": {
+        "backward": { "compatible": false },
+        "forward": { "compatible": true }
+      },
+      "original": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["string", "number", "boolean"]
+      },
+      "updated": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["string", "number"]
+      }
+    },
+    {
+      "enabled": true,
+      "id": "Multi-type: integer subset of number is compatible",
+      "compatibility": "both",
+      "original": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["string", "integer"]
+      },
+      "updated": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["string", "number"]
+      }
+    },
+    {
+      "enabled": true,
+      "id": "Multi-type: single to multi is backward compatible",
+      "compatibility": "backward",
+      "original": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "string"
+      },
+      "updated": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["string", "number"]
+      }
+    },
+    {
+      "enabled": true,
+      "id": "Multi-type: different order is compatible",
+      "compatibility": "both",
+      "original": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["number", "string"]
+      },
+      "updated": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": ["string", "number"]
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Multi-valued type: compare as sets, types added = backward compatible, types removed = incompatible, integer/number normalization. 6 test cases.
- Modern test data: 8 additional test cases for cross-version definitions↔$defs, $recursiveRef, $dynamicRef, if/then/else, dependentRequired member changes, composition, enum/const.

## Context
C41 and C41b in #1042.

## Test plan
- [x] All 174 CC data-driven tests pass