### PR TITLE
feat(generator): beforeVisit/afterVisit callbacks on regular traverser (G13c)

### DIFF
--- a/data-models/src/main/java/io/apitomy/datamodels/transform/OpenApi20to30TransformationVisitor.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/transform/OpenApi20to30TransformationVisitor.java
@@ -53,7 +53,7 @@ import io.apitomy.datamodels.models.openapi.v2x.v20.OpenApi20Schema;
 import io.apitomy.datamodels.models.openapi.v2x.v20.OpenApi20SecurityRequirement;
 import io.apitomy.datamodels.models.openapi.v2x.v20.OpenApi20SecurityScheme;
 import io.apitomy.datamodels.models.openapi.v2x.v20.OpenApi20XML;
-import io.apitomy.datamodels.models.openapi.v2x.v20.visitors.OpenApi20Visitor;
+import io.apitomy.datamodels.models.openapi.v2x.v20.visitors.OpenApi20VisitorAdapter;
 import io.apitomy.datamodels.models.openapi.v3x.OpenApi3xMediaType;
 import io.apitomy.datamodels.models.openapi.v3x.v30.OpenApi30Components;
 import io.apitomy.datamodels.models.openapi.v3x.v30.OpenApi30Contact;
@@ -101,7 +101,7 @@ import java.util.Map;
  * A visitor used to transform an OpenAPI 2.0 document into an OpenAPI 3.0.x document.
  * @author eric.wittmann@gmail.com
  */
-public class OpenApi20to30TransformationVisitor implements OpenApi20Visitor, TraversingVisitor {
+public class OpenApi20to30TransformationVisitor extends OpenApi20VisitorAdapter implements TraversingVisitor {
 
     private OpenApi30Document doc30;
     private TraversalContext traversalContext;

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractVisitorStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractVisitorStage.java
@@ -1,5 +1,6 @@
 package io.apitomy.umg.pipe.java;
 
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -43,6 +44,47 @@ public abstract class AbstractVisitorStage extends AbstractJavaStage {
             visitor = visitor.getParent();
         }
         return methods;
+    }
+
+    protected List<MethodSource<?>> getVisitMethodsOnly(VisitorModel visitor) {
+        return getAllMethodsForVisitorInterface(visitor).stream()
+                .filter(m -> m.getName().startsWith("visit"))
+                .collect(Collectors.toList());
+    }
+
+    protected List<MethodSource<?>> getBeforeAfterMethodsOnly(VisitorModel visitor) {
+        return getAllMethodsForVisitorInterface(visitor).stream()
+                .filter(m -> m.getName().startsWith("beforeVisit") || m.getName().startsWith("afterVisit"))
+                .collect(Collectors.toList());
+    }
+
+    protected void addBeforeAfterImplementations(org.jboss.forge.roaster.model.source.JavaClassSource classSource,
+                                                  VisitorModel visitor) {
+        Set<String> methodNames = new HashSet<>();
+        for (MethodSource<?> method : getBeforeAfterMethodsOnly(visitor)) {
+            if (methodNames.contains(method.getName())) {
+                continue;
+            }
+            methodNames.add(method.getName());
+
+            boolean isBefore = method.getName().startsWith("beforeVisit");
+            org.jboss.forge.roaster.model.source.ParameterSource<?> param = method.getParameters().get(0);
+            classSource.addImport(param.getType());
+
+            MethodSource<org.jboss.forge.roaster.model.source.JavaClassSource> methodSource = classSource.addMethod()
+                    .setName(method.getName())
+                    .setPublic();
+            methodSource.addParameter(param.getType().getSimpleName(), param.getName());
+            methodSource.addAnnotation(Override.class);
+
+            if (isBefore) {
+                methodSource.setReturnType(boolean.class);
+                methodSource.setBody("return true;");
+            } else {
+                methodSource.setReturnTypeVoid();
+                methodSource.setBody("");
+            }
+        }
     }
 
 }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateAllNodeVisitorStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateAllNodeVisitorStage.java
@@ -83,18 +83,41 @@ public class CreateAllNodeVisitorStage extends AbstractVisitorStage {
                 .setReturnTypeVoid().setProtected().setAbstract(true);
         visitNodeMethod.addParameter("Node", "node");
 
-        // Now create an implementation for each visit method.
+        // Create beforeVisitNode / afterVisitNode hooks
+        MethodSource<JavaClassSource> beforeMethod = allNodeVisitorSource.addMethod().setName("beforeVisitNode")
+                .setReturnType(boolean.class).setProtected();
+        beforeMethod.addParameter("Node", "node");
+        beforeMethod.setBody("return true;");
+
+        MethodSource<JavaClassSource> afterMethod = allNodeVisitorSource.addMethod().setName("afterVisitNode")
+                .setReturnTypeVoid().setProtected();
+        afterMethod.addParameter("Node", "node");
+        afterMethod.setBody("");
+
+        // Now create an implementation for each visit/beforeVisit/afterVisit method.
         methodsToImplement.forEach(method -> {
+            String name = method.getName();
+            boolean isBefore = name.startsWith("beforeVisit");
+            boolean isAfter = name.startsWith("afterVisit");
+
             MethodSource<JavaClassSource> methodSource = allNodeVisitorSource.addMethod()
-                    .setName(method.getName())
-                    .setReturnTypeVoid()
+                    .setName(name)
                     .setPublic();
-            // We know each visit method will have a single parameter.
             ParameterSource<?> param = method.getParameters().get(0);
             allNodeVisitorSource.addImport(param.getType());
             methodSource.addParameter(param.getType().getSimpleName(), param.getName());
             methodSource.addAnnotation(Override.class);
-            methodSource.setBody("this.visitNode(node);");
+
+            if (isBefore) {
+                methodSource.setReturnType(boolean.class);
+                methodSource.setBody("return this.beforeVisitNode(node);");
+            } else if (isAfter) {
+                methodSource.setReturnTypeVoid();
+                methodSource.setBody("this.afterVisitNode(node);");
+            } else {
+                methodSource.setReturnTypeVoid();
+                methodSource.setBody("this.visitNode(node);");
+            }
         });
 
         // Index the new class

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonerDispatchersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonerDispatchersStage.java
@@ -63,7 +63,7 @@ public class CreateClonerDispatchersStage extends AbstractVisitorStage {
             dispatcherSource.addImport(vtiInterface);
             dispatcherSource.addInterface(vtiInterface.getName());
 
-            List<MethodSource<?>> allMethods = getAllMethodsForVisitorInterface(visitorToImplement);
+            List<MethodSource<?>> allMethods = getVisitMethodsOnly(visitorToImplement);
             allMethods.forEach(method -> {
                 if (!methodNames.contains(method.getName())) {
                     methodsToImplement.add(method);
@@ -130,6 +130,7 @@ public class CreateClonerDispatchersStage extends AbstractVisitorStage {
             methodSource.setBody(body.toString());
         });
 
+        addBeforeAfterImplementations(dispatcherSource, visitor);
         getState().getJavaIndex().index(dispatcherSource);
     }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReaderDispatchersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReaderDispatchersStage.java
@@ -69,7 +69,7 @@ public class CreateReaderDispatchersStage extends AbstractVisitorStage {
             readerDispatcherSource.addInterface(vtiInterface.getName());
 
             // Add all methods to the list (but avoid duplicates).
-            List<MethodSource<?>> allMethods = getAllMethodsForVisitorInterface(visitorToImplement);
+            List<MethodSource<?>> allMethods = getVisitMethodsOnly(visitorToImplement);
             allMethods.forEach(method -> {
                 if (!methodNames.contains(method.getName())) {
                     methodsToImplement.add(method);
@@ -121,6 +121,7 @@ public class CreateReaderDispatchersStage extends AbstractVisitorStage {
         });
 
         // Index the new class
+        addBeforeAfterImplementations(readerDispatcherSource, visitor);
         getState().getJavaIndex().index(readerDispatcherSource);
     }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateTraversersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateTraversersStage.java
@@ -77,8 +77,7 @@ public class CreateTraversersStage extends AbstractVisitorStage {
             traverserSource.addImport(vtiInterface);
             traverserSource.addInterface(vtiInterface);
 
-            // Add all methods to the list (but avoid duplicates).
-            List<MethodSource<?>> allMethods = getAllMethodsForVisitorInterface(visitorToImplement);
+            List<MethodSource<?>> allMethods = getVisitMethodsOnly(visitorToImplement);
             allMethods.forEach(method -> {
                 if (!methodNames.contains(method.getName())) {
                     methodsToImplement.add(method);
@@ -104,18 +103,49 @@ public class CreateTraversersStage extends AbstractVisitorStage {
             String entityName = method.getName().replace("visit", "");
             EntityModel entityModel = getState().getConceptIndex().lookupEntity(entityNamespace, entityName);
 
-            String body = createTraversalMethodBody(entityModel, traverserSource);
+            String visitorTypeName = lookupJavaVisitor(visitor).getName();
+            String body = createTraversalMethodBody(entityModel, traverserSource, visitorTypeName);
             methodSource.setBody(body);
+        });
+
+        // Also implement beforeVisit/afterVisit by delegating to the user's visitor
+        methodsToImplement.forEach(method -> {
+            String entityName = method.getName().replace("visit", "");
+            ParameterSource<?> param = method.getParameters().get(0);
+            String paramType = param.getType().getSimpleName();
+
+            // beforeVisitXyz
+            MethodSource<JavaClassSource> beforeMethod = traverserSource.addMethod()
+                    .setName("beforeVisit" + entityName)
+                    .setReturnType(boolean.class)
+                    .setPublic();
+            beforeMethod.addParameter(paramType, param.getName());
+            beforeMethod.addAnnotation(Override.class);
+            beforeMethod.setBody("return true;");
+
+            // afterVisitXyz
+            MethodSource<JavaClassSource> afterMethod = traverserSource.addMethod()
+                    .setName("afterVisit" + entityName)
+                    .setReturnTypeVoid()
+                    .setPublic();
+            afterMethod.addParameter(paramType, param.getName());
+            afterMethod.addAnnotation(Override.class);
+            afterMethod.setBody("");
         });
 
         // Index the new class
         getState().getJavaIndex().index(traverserSource);
     }
 
-    private String createTraversalMethodBody(EntityModel entityModel, JavaClassSource traverserSource) {
+    private String createTraversalMethodBody(EntityModel entityModel, JavaClassSource traverserSource, String visitorTypeName) {
         JavaInterfaceSource javaEntity = lookupJavaEntity(entityModel);
 
         BodyBuilder body = new BodyBuilder();
+
+        body.addContext("entityName", entityModel.getName());
+        body.addContext("visitorType", visitorTypeName);
+        body.append("if (((${visitorType}) this.visitor).beforeVisit${entityName}(node)) {");
+
         body.append("node.accept(this.visitor);");
 
         Collection<PropertyModel> allProperties = getState().getConceptIndex().getAllEntityProperties(entityModel).stream().map(property -> property.getProperty()).filter(property -> {
@@ -157,6 +187,9 @@ public class CreateTraversersStage extends AbstractVisitorStage {
                 warn("Unhandled property in traverser: " + property);
             }
         });
+
+        body.append("}");
+        body.append("((${visitorType}) this.visitor).afterVisit${entityName}(node);");
 
         return body.toString();
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateVisitorAdaptersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateVisitorAdaptersStage.java
@@ -96,16 +96,23 @@ public class CreateVisitorAdaptersStage extends AbstractVisitorStage {
 
         // Now create an empty implementation for each visit method.
         methodsToImplement.forEach(method -> {
+            boolean isBooleanReturn = method.getName().startsWith("beforeVisit");
+
             MethodSource<JavaClassSource> methodSource = visitorAdapterSource.addMethod()
                     .setName(method.getName())
-                    .setReturnTypeVoid()
                     .setPublic();
+            if (isBooleanReturn) {
+                methodSource.setReturnType(boolean.class);
+                methodSource.setBody("return true;");
+            } else {
+                methodSource.setReturnTypeVoid();
+                methodSource.setBody("");
+            }
             // We know each visit method will have a single parameter.
             ParameterSource<?> param = method.getParameters().get(0);
             visitorAdapterSource.addImport(param.getType());
             methodSource.addParameter(param.getType().getSimpleName(), param.getName());
             methodSource.addAnnotation(Override.class);
-            methodSource.setBody("");
         });
 
         // Index the new class

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateVisitorInterfacesStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateVisitorInterfacesStage.java
@@ -44,9 +44,11 @@ public class CreateVisitorInterfacesStage extends AbstractVisitorStage {
             visitorInterfaceSource.addInterface(parentVisitorInterface.getName());
         }
 
-        // Now create visitXyz methods for each entity in the visitor
+        // Now create visitXyz, beforeVisitXyz, and afterVisitXyz methods for each entity
         visitor.getEntities().forEach(entity -> {
             createVisitMethodFor(visitorInterfaceSource, entity);
+            createBeforeVisitMethodFor(visitorInterfaceSource, entity);
+            createAfterVisitMethodFor(visitorInterfaceSource, entity);
         });
 
         getState().getJavaIndex().index(visitorInterfaceSource);
@@ -57,10 +59,12 @@ public class CreateVisitorInterfacesStage extends AbstractVisitorStage {
         });
     }
 
-    /**
-     * Creates the readXyz() method for the given entity.
-     *
-     */
+    // visitXyz is the main visitor callback, called by node.accept(visitor).
+    // It is separate from beforeVisitXyz to keep backward compatibility (void return)
+    // and because the traversal gate (before) and the work (visit) are separate concerns
+    // for the regular visitor. If in the future we want to merge them (like the DiffVisitor's
+    // boolean visitXyz pattern), we would change visitXyz to return boolean and remove
+    // beforeVisitXyz.
     private void createVisitMethodFor(JavaInterfaceSource visitorInterfaceSource, EntityModel entity) {
         String visitMethodName = "visit" + entity.getName();
 
@@ -74,6 +78,36 @@ public class CreateVisitorInterfacesStage extends AbstractVisitorStage {
 
         MethodSource<JavaInterfaceSource> methodSource = visitorInterfaceSource.addMethod()
                 .setName(visitMethodName)
+                .setReturnTypeVoid()
+                .setPublic();
+        methodSource.addParameter(javaEntityModel.getName(), "node");
+    }
+
+    private void createBeforeVisitMethodFor(JavaInterfaceSource visitorInterfaceSource, EntityModel entity) {
+        String methodName = "beforeVisit" + entity.getName();
+
+        JavaInterfaceSource javaEntityModel = findRootJavaEntity(entity);
+        if (javaEntityModel == null) {
+            return;
+        }
+
+        MethodSource<JavaInterfaceSource> methodSource = visitorInterfaceSource.addMethod()
+                .setName(methodName)
+                .setReturnType(boolean.class)
+                .setPublic();
+        methodSource.addParameter(javaEntityModel.getName(), "node");
+    }
+
+    private void createAfterVisitMethodFor(JavaInterfaceSource visitorInterfaceSource, EntityModel entity) {
+        String methodName = "afterVisit" + entity.getName();
+
+        JavaInterfaceSource javaEntityModel = findRootJavaEntity(entity);
+        if (javaEntityModel == null) {
+            return;
+        }
+
+        MethodSource<JavaInterfaceSource> methodSource = visitorInterfaceSource.addMethod()
+                .setName(methodName)
                 .setReturnTypeVoid()
                 .setPublic();
         methodSource.addParameter(javaEntityModel.getName(), "node");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWriterDispatchersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWriterDispatchersStage.java
@@ -69,7 +69,7 @@ public class CreateWriterDispatchersStage extends AbstractVisitorStage {
             writerDispatcherSource.addInterface(vtiInterface.getName());
 
             // Add all methods to the list (but avoid duplicates).
-            List<MethodSource<?>> allMethods = getAllMethodsForVisitorInterface(visitorToImplement);
+            List<MethodSource<?>> allMethods = getVisitMethodsOnly(visitorToImplement);
             allMethods.forEach(method -> {
                 if (!methodNames.contains(method.getName())) {
                     methodsToImplement.add(method);
@@ -121,6 +121,7 @@ public class CreateWriterDispatchersStage extends AbstractVisitorStage {
         });
 
         // Index the new class
+        addBeforeAfterImplementations(writerDispatcherSource, visitor);
         getState().getJavaIndex().index(writerDispatcherSource);
     }
 

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelClonerDispatcher.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelClonerDispatcher.java
@@ -75,4 +75,76 @@ public class Syn1ModelClonerDispatcher implements Syn1Visitor, ModelCloner {
 	public void visitItem(SynItem node) {
 		this.cloner.cloneItem((Syn1Item) node, (Syn1Item) this.clonedNode);
 	}
+
+	@Override
+	public boolean beforeVisitPaths(SynPaths node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPaths(SynPaths node) {
+	}
+
+	@Override
+	public boolean beforeVisitOperation(SynOperation node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitOperation(SynOperation node) {
+	}
+
+	@Override
+	public boolean beforeVisitSchema(SynSchema node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitSchema(SynSchema node) {
+	}
+
+	@Override
+	public boolean beforeVisitInfo(SynInfo node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitInfo(SynInfo node) {
+	}
+
+	@Override
+	public boolean beforeVisitPathItem(SynPathItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPathItem(SynPathItem node) {
+	}
+
+	@Override
+	public boolean beforeVisitDocument(SynDocument node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitDocument(SynDocument node) {
+	}
+
+	@Override
+	public boolean beforeVisitContact(SynContact node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitContact(SynContact node) {
+	}
+
+	@Override
+	public boolean beforeVisitItem(SynItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitItem(SynItem node) {
+	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReaderDispatcher.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReaderDispatcher.java
@@ -68,4 +68,76 @@ public class Syn1ModelReaderDispatcher implements Syn1Visitor {
 	public void visitItem(SynItem node) {
 		this.reader.readItem(this.json, (Syn1Item) node);
 	}
+
+	@Override
+	public boolean beforeVisitPaths(SynPaths node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPaths(SynPaths node) {
+	}
+
+	@Override
+	public boolean beforeVisitOperation(SynOperation node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitOperation(SynOperation node) {
+	}
+
+	@Override
+	public boolean beforeVisitSchema(SynSchema node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitSchema(SynSchema node) {
+	}
+
+	@Override
+	public boolean beforeVisitInfo(SynInfo node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitInfo(SynInfo node) {
+	}
+
+	@Override
+	public boolean beforeVisitPathItem(SynPathItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPathItem(SynPathItem node) {
+	}
+
+	@Override
+	public boolean beforeVisitDocument(SynDocument node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitDocument(SynDocument node) {
+	}
+
+	@Override
+	public boolean beforeVisitContact(SynContact node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitContact(SynContact node) {
+	}
+
+	@Override
+	public boolean beforeVisitItem(SynItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitItem(SynItem node) {
+	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelWriterDispatcher.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelWriterDispatcher.java
@@ -68,4 +68,76 @@ public class Syn1ModelWriterDispatcher implements Syn1Visitor {
 	public void visitItem(SynItem node) {
 		this.writer.writeItem((Syn1Item) node, this.json);
 	}
+
+	@Override
+	public boolean beforeVisitPaths(SynPaths node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPaths(SynPaths node) {
+	}
+
+	@Override
+	public boolean beforeVisitOperation(SynOperation node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitOperation(SynOperation node) {
+	}
+
+	@Override
+	public boolean beforeVisitSchema(SynSchema node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitSchema(SynSchema node) {
+	}
+
+	@Override
+	public boolean beforeVisitInfo(SynInfo node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitInfo(SynInfo node) {
+	}
+
+	@Override
+	public boolean beforeVisitPathItem(SynPathItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPathItem(SynPathItem node) {
+	}
+
+	@Override
+	public boolean beforeVisitDocument(SynDocument node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitDocument(SynDocument node) {
+	}
+
+	@Override
+	public boolean beforeVisitContact(SynContact node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitContact(SynContact node) {
+	}
+
+	@Override
+	public boolean beforeVisitItem(SynItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitItem(SynItem node) {
+	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1Traverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1Traverser.java
@@ -26,65 +26,161 @@ public class Syn1Traverser extends AbstractTraverser implements Syn1Visitor {
 
 	@Override
 	public void visitPaths(SynPaths node) {
-		node.accept(this.visitor);
-		Syn1Paths model = (Syn1Paths) node;
-		this.traverseMappedNode(model);
+		if (((Syn1Visitor) this.visitor).beforeVisitPaths(node)) {
+			node.accept(this.visitor);
+			Syn1Paths model = (Syn1Paths) node;
+			this.traverseMappedNode(model);
+		}
+		((Syn1Visitor) this.visitor).afterVisitPaths(node);
 	}
 
 	@Override
 	public void visitOperation(SynOperation node) {
-		node.accept(this.visitor);
-		Syn1Operation model = (Syn1Operation) node;
-		this.traverseList("parameters", model.getParameters());
+		if (((Syn1Visitor) this.visitor).beforeVisitOperation(node)) {
+			node.accept(this.visitor);
+			Syn1Operation model = (Syn1Operation) node;
+			this.traverseList("parameters", model.getParameters());
+		}
+		((Syn1Visitor) this.visitor).afterVisitOperation(node);
 	}
 
 	@Override
 	public void visitSchema(SynSchema node) {
-		node.accept(this.visitor);
-		Syn1Schema model = (Syn1Schema) node;
-		this.traverseUnion("items", model.getItems());
-		this.traverseMap("properties", model.getProperties());
-		this.traverseList("allOf", model.getAllOf());
-		this.traverseMap("definitions", model.getDefinitions());
-		this.traverseMap("nestedSchemas", model.getNestedSchemas());
-		this.traverseList("composedSchemas", model.getComposedSchemas());
+		if (((Syn1Visitor) this.visitor).beforeVisitSchema(node)) {
+			node.accept(this.visitor);
+			Syn1Schema model = (Syn1Schema) node;
+			this.traverseUnion("items", model.getItems());
+			this.traverseMap("properties", model.getProperties());
+			this.traverseList("allOf", model.getAllOf());
+			this.traverseMap("definitions", model.getDefinitions());
+			this.traverseMap("nestedSchemas", model.getNestedSchemas());
+			this.traverseList("composedSchemas", model.getComposedSchemas());
+		}
+		((Syn1Visitor) this.visitor).afterVisitSchema(node);
 	}
 
 	@Override
 	public void visitInfo(SynInfo node) {
-		node.accept(this.visitor);
-		Syn1Info model = (Syn1Info) node;
-		this.traverseNode("contact", model.getContact());
+		if (((Syn1Visitor) this.visitor).beforeVisitInfo(node)) {
+			node.accept(this.visitor);
+			Syn1Info model = (Syn1Info) node;
+			this.traverseNode("contact", model.getContact());
+		}
+		((Syn1Visitor) this.visitor).afterVisitInfo(node);
 	}
 
 	@Override
 	public void visitPathItem(SynPathItem node) {
-		node.accept(this.visitor);
-		Syn1PathItem model = (Syn1PathItem) node;
-		this.traverseNode("get", model.getGet());
-		this.traverseNode("put", model.getPut());
-		this.traverseNode("post", model.getPost());
+		if (((Syn1Visitor) this.visitor).beforeVisitPathItem(node)) {
+			node.accept(this.visitor);
+			Syn1PathItem model = (Syn1PathItem) node;
+			this.traverseNode("get", model.getGet());
+			this.traverseNode("put", model.getPut());
+			this.traverseNode("post", model.getPost());
+		}
+		((Syn1Visitor) this.visitor).afterVisitPathItem(node);
 	}
 
 	@Override
 	public void visitDocument(SynDocument node) {
-		node.accept(this.visitor);
-		Syn1Document model = (Syn1Document) node;
-		this.traverseNode("info", model.getInfo());
-		this.traverseList("items", model.getItems());
-		this.traverseUnion("additionalSchema", model.getAdditionalSchema());
+		if (((Syn1Visitor) this.visitor).beforeVisitDocument(node)) {
+			node.accept(this.visitor);
+			Syn1Document model = (Syn1Document) node;
+			this.traverseNode("info", model.getInfo());
+			this.traverseList("items", model.getItems());
+			this.traverseUnion("additionalSchema", model.getAdditionalSchema());
+		}
+		((Syn1Visitor) this.visitor).afterVisitDocument(node);
 	}
 
 	@Override
 	public void visitContact(SynContact node) {
-		node.accept(this.visitor);
+		if (((Syn1Visitor) this.visitor).beforeVisitContact(node)) {
+			node.accept(this.visitor);
+		}
+		((Syn1Visitor) this.visitor).afterVisitContact(node);
 	}
 
 	@Override
 	public void visitItem(SynItem node) {
-		node.accept(this.visitor);
-		Syn1Item model = (Syn1Item) node;
-		this.traverseNode("schema", model.getSchema());
-		this.traverseUnion("defaultValue", model.getDefaultValue());
+		if (((Syn1Visitor) this.visitor).beforeVisitItem(node)) {
+			node.accept(this.visitor);
+			Syn1Item model = (Syn1Item) node;
+			this.traverseNode("schema", model.getSchema());
+			this.traverseUnion("defaultValue", model.getDefaultValue());
+		}
+		((Syn1Visitor) this.visitor).afterVisitItem(node);
+	}
+
+	@Override
+	public boolean beforeVisitPaths(SynPaths node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPaths(SynPaths node) {
+	}
+
+	@Override
+	public boolean beforeVisitOperation(SynOperation node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitOperation(SynOperation node) {
+	}
+
+	@Override
+	public boolean beforeVisitSchema(SynSchema node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitSchema(SynSchema node) {
+	}
+
+	@Override
+	public boolean beforeVisitInfo(SynInfo node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitInfo(SynInfo node) {
+	}
+
+	@Override
+	public boolean beforeVisitPathItem(SynPathItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPathItem(SynPathItem node) {
+	}
+
+	@Override
+	public boolean beforeVisitDocument(SynDocument node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitDocument(SynDocument node) {
+	}
+
+	@Override
+	public boolean beforeVisitContact(SynContact node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitContact(SynContact node) {
+	}
+
+	@Override
+	public boolean beforeVisitItem(SynItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitItem(SynItem node) {
 	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1VisitorAdapter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1VisitorAdapter.java
@@ -16,7 +16,25 @@ public class Syn1VisitorAdapter implements Syn1Visitor {
 	}
 
 	@Override
+	public boolean beforeVisitPaths(SynPaths node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPaths(SynPaths node) {
+	}
+
+	@Override
 	public void visitOperation(SynOperation node) {
+	}
+
+	@Override
+	public boolean beforeVisitOperation(SynOperation node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitOperation(SynOperation node) {
 	}
 
 	@Override
@@ -24,7 +42,25 @@ public class Syn1VisitorAdapter implements Syn1Visitor {
 	}
 
 	@Override
+	public boolean beforeVisitSchema(SynSchema node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitSchema(SynSchema node) {
+	}
+
+	@Override
 	public void visitInfo(SynInfo node) {
+	}
+
+	@Override
+	public boolean beforeVisitInfo(SynInfo node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitInfo(SynInfo node) {
 	}
 
 	@Override
@@ -32,7 +68,25 @@ public class Syn1VisitorAdapter implements Syn1Visitor {
 	}
 
 	@Override
+	public boolean beforeVisitPathItem(SynPathItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPathItem(SynPathItem node) {
+	}
+
+	@Override
 	public void visitDocument(SynDocument node) {
+	}
+
+	@Override
+	public boolean beforeVisitDocument(SynDocument node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitDocument(SynDocument node) {
 	}
 
 	@Override
@@ -40,6 +94,24 @@ public class Syn1VisitorAdapter implements Syn1Visitor {
 	}
 
 	@Override
+	public boolean beforeVisitContact(SynContact node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitContact(SynContact node) {
+	}
+
+	@Override
 	public void visitItem(SynItem node) {
+	}
+
+	@Override
+	public boolean beforeVisitItem(SynItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitItem(SynItem node) {
 	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelClonerDispatcher.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelClonerDispatcher.java
@@ -75,4 +75,76 @@ public class Syn2ModelClonerDispatcher implements Syn2Visitor, ModelCloner {
 	public void visitItem(SynItem node) {
 		this.cloner.cloneItem((Syn2Item) node, (Syn2Item) this.clonedNode);
 	}
+
+	@Override
+	public boolean beforeVisitPaths(SynPaths node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPaths(SynPaths node) {
+	}
+
+	@Override
+	public boolean beforeVisitOperation(SynOperation node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitOperation(SynOperation node) {
+	}
+
+	@Override
+	public boolean beforeVisitSchema(SynSchema node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitSchema(SynSchema node) {
+	}
+
+	@Override
+	public boolean beforeVisitInfo(SynInfo node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitInfo(SynInfo node) {
+	}
+
+	@Override
+	public boolean beforeVisitPathItem(SynPathItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPathItem(SynPathItem node) {
+	}
+
+	@Override
+	public boolean beforeVisitDocument(SynDocument node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitDocument(SynDocument node) {
+	}
+
+	@Override
+	public boolean beforeVisitContact(SynContact node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitContact(SynContact node) {
+	}
+
+	@Override
+	public boolean beforeVisitItem(SynItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitItem(SynItem node) {
+	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReaderDispatcher.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReaderDispatcher.java
@@ -68,4 +68,76 @@ public class Syn2ModelReaderDispatcher implements Syn2Visitor {
 	public void visitItem(SynItem node) {
 		this.reader.readItem(this.json, (Syn2Item) node);
 	}
+
+	@Override
+	public boolean beforeVisitPaths(SynPaths node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPaths(SynPaths node) {
+	}
+
+	@Override
+	public boolean beforeVisitOperation(SynOperation node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitOperation(SynOperation node) {
+	}
+
+	@Override
+	public boolean beforeVisitSchema(SynSchema node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitSchema(SynSchema node) {
+	}
+
+	@Override
+	public boolean beforeVisitInfo(SynInfo node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitInfo(SynInfo node) {
+	}
+
+	@Override
+	public boolean beforeVisitPathItem(SynPathItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPathItem(SynPathItem node) {
+	}
+
+	@Override
+	public boolean beforeVisitDocument(SynDocument node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitDocument(SynDocument node) {
+	}
+
+	@Override
+	public boolean beforeVisitContact(SynContact node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitContact(SynContact node) {
+	}
+
+	@Override
+	public boolean beforeVisitItem(SynItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitItem(SynItem node) {
+	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelWriterDispatcher.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelWriterDispatcher.java
@@ -68,4 +68,76 @@ public class Syn2ModelWriterDispatcher implements Syn2Visitor {
 	public void visitItem(SynItem node) {
 		this.writer.writeItem((Syn2Item) node, this.json);
 	}
+
+	@Override
+	public boolean beforeVisitPaths(SynPaths node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPaths(SynPaths node) {
+	}
+
+	@Override
+	public boolean beforeVisitOperation(SynOperation node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitOperation(SynOperation node) {
+	}
+
+	@Override
+	public boolean beforeVisitSchema(SynSchema node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitSchema(SynSchema node) {
+	}
+
+	@Override
+	public boolean beforeVisitInfo(SynInfo node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitInfo(SynInfo node) {
+	}
+
+	@Override
+	public boolean beforeVisitPathItem(SynPathItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPathItem(SynPathItem node) {
+	}
+
+	@Override
+	public boolean beforeVisitDocument(SynDocument node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitDocument(SynDocument node) {
+	}
+
+	@Override
+	public boolean beforeVisitContact(SynContact node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitContact(SynContact node) {
+	}
+
+	@Override
+	public boolean beforeVisitItem(SynItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitItem(SynItem node) {
+	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2Traverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2Traverser.java
@@ -26,67 +26,163 @@ public class Syn2Traverser extends AbstractTraverser implements Syn2Visitor {
 
 	@Override
 	public void visitPaths(SynPaths node) {
-		node.accept(this.visitor);
-		Syn2Paths model = (Syn2Paths) node;
-		this.traverseMappedNode(model);
+		if (((Syn2Visitor) this.visitor).beforeVisitPaths(node)) {
+			node.accept(this.visitor);
+			Syn2Paths model = (Syn2Paths) node;
+			this.traverseMappedNode(model);
+		}
+		((Syn2Visitor) this.visitor).afterVisitPaths(node);
 	}
 
 	@Override
 	public void visitOperation(SynOperation node) {
-		node.accept(this.visitor);
-		Syn2Operation model = (Syn2Operation) node;
-		this.traverseList("parameters", model.getParameters());
+		if (((Syn2Visitor) this.visitor).beforeVisitOperation(node)) {
+			node.accept(this.visitor);
+			Syn2Operation model = (Syn2Operation) node;
+			this.traverseList("parameters", model.getParameters());
+		}
+		((Syn2Visitor) this.visitor).afterVisitOperation(node);
 	}
 
 	@Override
 	public void visitSchema(SynSchema node) {
-		node.accept(this.visitor);
-		Syn2Schema model = (Syn2Schema) node;
-		this.traverseUnion("items", model.getItems());
-		this.traverseMap("properties", model.getProperties());
-		this.traverseList("allOf", model.getAllOf());
-		this.traverseMap("definitions", model.getDefinitions());
-		this.traverseMap("nestedSchemas", model.getNestedSchemas());
-		this.traverseList("composedSchemas", model.getComposedSchemas());
+		if (((Syn2Visitor) this.visitor).beforeVisitSchema(node)) {
+			node.accept(this.visitor);
+			Syn2Schema model = (Syn2Schema) node;
+			this.traverseUnion("items", model.getItems());
+			this.traverseMap("properties", model.getProperties());
+			this.traverseList("allOf", model.getAllOf());
+			this.traverseMap("definitions", model.getDefinitions());
+			this.traverseMap("nestedSchemas", model.getNestedSchemas());
+			this.traverseList("composedSchemas", model.getComposedSchemas());
+		}
+		((Syn2Visitor) this.visitor).afterVisitSchema(node);
 	}
 
 	@Override
 	public void visitInfo(SynInfo node) {
-		node.accept(this.visitor);
-		Syn2Info model = (Syn2Info) node;
-		this.traverseNode("contact", model.getContact());
+		if (((Syn2Visitor) this.visitor).beforeVisitInfo(node)) {
+			node.accept(this.visitor);
+			Syn2Info model = (Syn2Info) node;
+			this.traverseNode("contact", model.getContact());
+		}
+		((Syn2Visitor) this.visitor).afterVisitInfo(node);
 	}
 
 	@Override
 	public void visitPathItem(SynPathItem node) {
-		node.accept(this.visitor);
-		Syn2PathItem model = (Syn2PathItem) node;
-		this.traverseNode("get", model.getGet());
-		this.traverseNode("put", model.getPut());
-		this.traverseNode("post", model.getPost());
-		this.traverseNode("delete", model.getDelete());
+		if (((Syn2Visitor) this.visitor).beforeVisitPathItem(node)) {
+			node.accept(this.visitor);
+			Syn2PathItem model = (Syn2PathItem) node;
+			this.traverseNode("get", model.getGet());
+			this.traverseNode("put", model.getPut());
+			this.traverseNode("post", model.getPost());
+			this.traverseNode("delete", model.getDelete());
+		}
+		((Syn2Visitor) this.visitor).afterVisitPathItem(node);
 	}
 
 	@Override
 	public void visitDocument(SynDocument node) {
-		node.accept(this.visitor);
-		Syn2Document model = (Syn2Document) node;
-		this.traverseNode("info", model.getInfo());
-		this.traverseList("items", model.getItems());
-		this.traverseMap("webhooks", model.getWebhooks());
-		this.traverseUnion("additionalSchema", model.getAdditionalSchema());
+		if (((Syn2Visitor) this.visitor).beforeVisitDocument(node)) {
+			node.accept(this.visitor);
+			Syn2Document model = (Syn2Document) node;
+			this.traverseNode("info", model.getInfo());
+			this.traverseList("items", model.getItems());
+			this.traverseMap("webhooks", model.getWebhooks());
+			this.traverseUnion("additionalSchema", model.getAdditionalSchema());
+		}
+		((Syn2Visitor) this.visitor).afterVisitDocument(node);
 	}
 
 	@Override
 	public void visitContact(SynContact node) {
-		node.accept(this.visitor);
+		if (((Syn2Visitor) this.visitor).beforeVisitContact(node)) {
+			node.accept(this.visitor);
+		}
+		((Syn2Visitor) this.visitor).afterVisitContact(node);
 	}
 
 	@Override
 	public void visitItem(SynItem node) {
-		node.accept(this.visitor);
-		Syn2Item model = (Syn2Item) node;
-		this.traverseNode("schema", model.getSchema());
-		this.traverseUnion("defaultValue", model.getDefaultValue());
+		if (((Syn2Visitor) this.visitor).beforeVisitItem(node)) {
+			node.accept(this.visitor);
+			Syn2Item model = (Syn2Item) node;
+			this.traverseNode("schema", model.getSchema());
+			this.traverseUnion("defaultValue", model.getDefaultValue());
+		}
+		((Syn2Visitor) this.visitor).afterVisitItem(node);
+	}
+
+	@Override
+	public boolean beforeVisitPaths(SynPaths node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPaths(SynPaths node) {
+	}
+
+	@Override
+	public boolean beforeVisitOperation(SynOperation node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitOperation(SynOperation node) {
+	}
+
+	@Override
+	public boolean beforeVisitSchema(SynSchema node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitSchema(SynSchema node) {
+	}
+
+	@Override
+	public boolean beforeVisitInfo(SynInfo node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitInfo(SynInfo node) {
+	}
+
+	@Override
+	public boolean beforeVisitPathItem(SynPathItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPathItem(SynPathItem node) {
+	}
+
+	@Override
+	public boolean beforeVisitDocument(SynDocument node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitDocument(SynDocument node) {
+	}
+
+	@Override
+	public boolean beforeVisitContact(SynContact node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitContact(SynContact node) {
+	}
+
+	@Override
+	public boolean beforeVisitItem(SynItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitItem(SynItem node) {
 	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2VisitorAdapter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2VisitorAdapter.java
@@ -16,7 +16,25 @@ public class Syn2VisitorAdapter implements Syn2Visitor {
 	}
 
 	@Override
+	public boolean beforeVisitPaths(SynPaths node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPaths(SynPaths node) {
+	}
+
+	@Override
 	public void visitOperation(SynOperation node) {
+	}
+
+	@Override
+	public boolean beforeVisitOperation(SynOperation node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitOperation(SynOperation node) {
 	}
 
 	@Override
@@ -24,7 +42,25 @@ public class Syn2VisitorAdapter implements Syn2Visitor {
 	}
 
 	@Override
+	public boolean beforeVisitSchema(SynSchema node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitSchema(SynSchema node) {
+	}
+
+	@Override
 	public void visitInfo(SynInfo node) {
+	}
+
+	@Override
+	public boolean beforeVisitInfo(SynInfo node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitInfo(SynInfo node) {
 	}
 
 	@Override
@@ -32,7 +68,25 @@ public class Syn2VisitorAdapter implements Syn2Visitor {
 	}
 
 	@Override
+	public boolean beforeVisitPathItem(SynPathItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPathItem(SynPathItem node) {
+	}
+
+	@Override
 	public void visitDocument(SynDocument node) {
+	}
+
+	@Override
+	public boolean beforeVisitDocument(SynDocument node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitDocument(SynDocument node) {
 	}
 
 	@Override
@@ -40,6 +94,24 @@ public class Syn2VisitorAdapter implements Syn2Visitor {
 	}
 
 	@Override
+	public boolean beforeVisitContact(SynContact node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitContact(SynContact node) {
+	}
+
+	@Override
 	public void visitItem(SynItem node) {
+	}
+
+	@Override
+	public boolean beforeVisitItem(SynItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitItem(SynItem node) {
 	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/AllNodeVisitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/AllNodeVisitor.java
@@ -14,9 +14,26 @@ public abstract class AllNodeVisitor implements CombinedVisitor {
 
 	protected abstract void visitNode(Node node);
 
+	protected boolean beforeVisitNode(Node node) {
+		return true;
+	}
+
+	protected void afterVisitNode(Node node) {
+	}
+
 	@Override
 	public void visitPaths(SynPaths node) {
 		this.visitNode(node);
+	}
+
+	@Override
+	public boolean beforeVisitPaths(SynPaths node) {
+		return this.beforeVisitNode(node);
+	}
+
+	@Override
+	public void afterVisitPaths(SynPaths node) {
+		this.afterVisitNode(node);
 	}
 
 	@Override
@@ -25,8 +42,28 @@ public abstract class AllNodeVisitor implements CombinedVisitor {
 	}
 
 	@Override
+	public boolean beforeVisitOperation(SynOperation node) {
+		return this.beforeVisitNode(node);
+	}
+
+	@Override
+	public void afterVisitOperation(SynOperation node) {
+		this.afterVisitNode(node);
+	}
+
+	@Override
 	public void visitSchema(SynSchema node) {
 		this.visitNode(node);
+	}
+
+	@Override
+	public boolean beforeVisitSchema(SynSchema node) {
+		return this.beforeVisitNode(node);
+	}
+
+	@Override
+	public void afterVisitSchema(SynSchema node) {
+		this.afterVisitNode(node);
 	}
 
 	@Override
@@ -35,8 +72,28 @@ public abstract class AllNodeVisitor implements CombinedVisitor {
 	}
 
 	@Override
+	public boolean beforeVisitInfo(SynInfo node) {
+		return this.beforeVisitNode(node);
+	}
+
+	@Override
+	public void afterVisitInfo(SynInfo node) {
+		this.afterVisitNode(node);
+	}
+
+	@Override
 	public void visitPathItem(SynPathItem node) {
 		this.visitNode(node);
+	}
+
+	@Override
+	public boolean beforeVisitPathItem(SynPathItem node) {
+		return this.beforeVisitNode(node);
+	}
+
+	@Override
+	public void afterVisitPathItem(SynPathItem node) {
+		this.afterVisitNode(node);
 	}
 
 	@Override
@@ -45,12 +102,42 @@ public abstract class AllNodeVisitor implements CombinedVisitor {
 	}
 
 	@Override
+	public boolean beforeVisitDocument(SynDocument node) {
+		return this.beforeVisitNode(node);
+	}
+
+	@Override
+	public void afterVisitDocument(SynDocument node) {
+		this.afterVisitNode(node);
+	}
+
+	@Override
 	public void visitContact(SynContact node) {
 		this.visitNode(node);
 	}
 
 	@Override
+	public boolean beforeVisitContact(SynContact node) {
+		return this.beforeVisitNode(node);
+	}
+
+	@Override
+	public void afterVisitContact(SynContact node) {
+		this.afterVisitNode(node);
+	}
+
+	@Override
 	public void visitItem(SynItem node) {
 		this.visitNode(node);
+	}
+
+	@Override
+	public boolean beforeVisitItem(SynItem node) {
+		return this.beforeVisitNode(node);
+	}
+
+	@Override
+	public void afterVisitItem(SynItem node) {
+		this.afterVisitNode(node);
 	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/CombinedVisitorAdapter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/CombinedVisitorAdapter.java
@@ -18,7 +18,25 @@ public class CombinedVisitorAdapter implements Syn2Visitor, Syn1Visitor {
 	}
 
 	@Override
+	public boolean beforeVisitPaths(SynPaths node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPaths(SynPaths node) {
+	}
+
+	@Override
 	public void visitOperation(SynOperation node) {
+	}
+
+	@Override
+	public boolean beforeVisitOperation(SynOperation node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitOperation(SynOperation node) {
 	}
 
 	@Override
@@ -26,7 +44,25 @@ public class CombinedVisitorAdapter implements Syn2Visitor, Syn1Visitor {
 	}
 
 	@Override
+	public boolean beforeVisitSchema(SynSchema node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitSchema(SynSchema node) {
+	}
+
+	@Override
 	public void visitInfo(SynInfo node) {
+	}
+
+	@Override
+	public boolean beforeVisitInfo(SynInfo node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitInfo(SynInfo node) {
 	}
 
 	@Override
@@ -34,7 +70,25 @@ public class CombinedVisitorAdapter implements Syn2Visitor, Syn1Visitor {
 	}
 
 	@Override
+	public boolean beforeVisitPathItem(SynPathItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitPathItem(SynPathItem node) {
+	}
+
+	@Override
 	public void visitDocument(SynDocument node) {
+	}
+
+	@Override
+	public boolean beforeVisitDocument(SynDocument node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitDocument(SynDocument node) {
 	}
 
 	@Override
@@ -42,6 +96,24 @@ public class CombinedVisitorAdapter implements Syn2Visitor, Syn1Visitor {
 	}
 
 	@Override
+	public boolean beforeVisitContact(SynContact node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitContact(SynContact node) {
+	}
+
+	@Override
 	public void visitItem(SynItem node) {
+	}
+
+	@Override
+	public boolean beforeVisitItem(SynItem node) {
+		return true;
+	}
+
+	@Override
+	public void afterVisitItem(SynItem node) {
 	}
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/Visitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/Visitor.java
@@ -13,17 +13,49 @@ public interface Visitor {
 
 	public void visitPaths(SynPaths node);
 
+	public boolean beforeVisitPaths(SynPaths node);
+
+	public void afterVisitPaths(SynPaths node);
+
 	public void visitOperation(SynOperation node);
+
+	public boolean beforeVisitOperation(SynOperation node);
+
+	public void afterVisitOperation(SynOperation node);
 
 	public void visitSchema(SynSchema node);
 
+	public boolean beforeVisitSchema(SynSchema node);
+
+	public void afterVisitSchema(SynSchema node);
+
 	public void visitInfo(SynInfo node);
+
+	public boolean beforeVisitInfo(SynInfo node);
+
+	public void afterVisitInfo(SynInfo node);
 
 	public void visitPathItem(SynPathItem node);
 
+	public boolean beforeVisitPathItem(SynPathItem node);
+
+	public void afterVisitPathItem(SynPathItem node);
+
 	public void visitDocument(SynDocument node);
+
+	public boolean beforeVisitDocument(SynDocument node);
+
+	public void afterVisitDocument(SynDocument node);
 
 	public void visitContact(SynContact node);
 
+	public boolean beforeVisitContact(SynContact node);
+
+	public void afterVisitContact(SynContact node);
+
 	public void visitItem(SynItem node);
+
+	public boolean beforeVisitItem(SynItem node);
+
+	public void afterVisitItem(SynItem node);
 }


### PR DESCRIPTION
## Summary
- Add `beforeVisitXyz` (boolean, gates recursion) and `afterVisitXyz` (void, post-visit) to all visitor interfaces
- Traverser checks `beforeVisit` before recursing, calls `afterVisit` after
- Adapters, AllNodeVisitor, and dispatchers provide default implementations
- Enables ancestry tracking (push on before, pop on after) and subtree skipping
- Prerequisite for C41n (dereferencer using generated traverser)

## Context
G13c in #1041, enables C41n in #1042.

## Test plan
- [x] All 1147 tests pass
- [x] Snapshot test regenerated