### PR TITLE
refactor: use generated traverser in dereferencer (C41n)

### DIFF
--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/ref/JsonSchemaRefDereferencer.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/ref/JsonSchemaRefDereferencer.java
@@ -6,6 +6,8 @@ import io.apitomy.datamodels.models.Node;
 import io.apitomy.datamodels.models.Referenceable;
 import io.apitomy.datamodels.models.jsonschema.JFullSchema;
 import io.apitomy.datamodels.models.visitors.AllNodeVisitor;
+import io.apitomy.datamodels.models.visitors.TraversalContext;
+import io.apitomy.datamodels.models.visitors.TraversingVisitor;
 import io.apitomy.datamodels.util.NodeUtil;
 
 import java.util.ArrayList;
@@ -200,29 +202,45 @@ public class JsonSchemaRefDereferencer {
     }
 
     private void dereferenceChildren(JFullSchema node, DereferenceContext ctx) {
-        VisitorUtil.visitTree(node, new AllNodeVisitor() {
-            private boolean isRoot = true;
+        var visitor = new ChildSchemaVisitor(node, ctx);
+        VisitorUtil.visitTree(node, visitor, TraverserDirection.down);
+    }
 
-            @Override
-            protected void visitNode(Node n) {
-            }
+    private class ChildSchemaVisitor extends AllNodeVisitor implements TraversingVisitor {
+        private final JFullSchema root;
+        private final DereferenceContext ctx;
+        private boolean isRoot = true;
+        private TraversalContext traversalContext;
 
-            @Override
-            public boolean beforeVisitFullSchema(JFullSchema n) {
-                if (isRoot) {
-                    isRoot = false;
-                    return true;
-                }
-                return false;
-            }
+        ChildSchemaVisitor(JFullSchema root, DereferenceContext ctx) {
+            this.root = root;
+            this.ctx = ctx;
+        }
 
-            @Override
-            public void afterVisitFullSchema(JFullSchema n) {
-                if (n != node) {
-                    dereferenceNode(n, ctx);
-                }
+        @Override
+        public void setTraversalContext(TraversalContext context) {
+            this.traversalContext = context;
+        }
+
+        @Override
+        protected void visitNode(Node n) {
+        }
+
+        @Override
+        public void visitFullSchema(JFullSchema n) {
+            if (isRoot) {
+                isRoot = false;
+                return;
             }
-        }, TraverserDirection.down);
+            traversalContext.skip();
+        }
+
+        @Override
+        public void afterVisitFullSchema(JFullSchema n) {
+            if (n != root) {
+                dereferenceNode(n, ctx);
+            }
+        }
     }
 
     private void handleUnresolvable(String ref, DereferenceContext ctx) {

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/ref/JsonSchemaRefDereferencer.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/ref/JsonSchemaRefDereferencer.java
@@ -1,9 +1,11 @@
 package io.apitomy.datamodels.jsonschema.ref;
 
+import io.apitomy.datamodels.TraverserDirection;
+import io.apitomy.datamodels.VisitorUtil;
 import io.apitomy.datamodels.models.Node;
 import io.apitomy.datamodels.models.Referenceable;
 import io.apitomy.datamodels.models.jsonschema.JFullSchema;
-import io.apitomy.datamodels.models.jsonschema.JsonSchema;
+import io.apitomy.datamodels.models.visitors.AllNodeVisitor;
 import io.apitomy.datamodels.util.NodeUtil;
 
 import java.util.ArrayList;
@@ -198,63 +200,29 @@ public class JsonSchemaRefDereferencer {
     }
 
     private void dereferenceChildren(JFullSchema node, DereferenceContext ctx) {
-        dereferenceUnion(node, "not", ctx);
-        dereferenceUnion(node, "if", ctx);
-        dereferenceUnion(node, "then", ctx);
-        dereferenceUnion(node, "else", ctx);
-        dereferenceUnion(node, "items", ctx);
-        dereferenceUnion(node, "additionalItems", ctx);
-        dereferenceUnion(node, "contains", ctx);
-        dereferenceUnion(node, "additionalProperties", ctx);
-        dereferenceUnion(node, "propertyNames", ctx);
-        dereferenceUnion(node, "contentSchema", ctx);
-        dereferenceUnion(node, "unevaluatedItems", ctx);
-        dereferenceUnion(node, "unevaluatedProperties", ctx);
+        VisitorUtil.visitTree(node, new AllNodeVisitor() {
+            private boolean isRoot = true;
 
-        dereferenceSchemaList(node, "allOf", ctx);
-        dereferenceSchemaList(node, "anyOf", ctx);
-        dereferenceSchemaList(node, "oneOf", ctx);
-        dereferenceSchemaList(node, "prefixItems", ctx);
+            @Override
+            protected void visitNode(Node n) {
+            }
 
-        dereferenceSchemaMap(node, "definitions", ctx);
-        dereferenceSchemaMap(node, "$defs", ctx);
-        dereferenceSchemaMap(node, "properties", ctx);
-        dereferenceSchemaMap(node, "patternProperties", ctx);
-        dereferenceSchemaMap(node, "dependencies", ctx);
-        dereferenceSchemaMap(node, "dependentSchemas", ctx);
-    }
+            @Override
+            public boolean beforeVisitFullSchema(JFullSchema n) {
+                if (isRoot) {
+                    isRoot = false;
+                    return true;
+                }
+                return false;
+            }
 
-    private void dereferenceUnion(Node parent, String propertyName, DereferenceContext ctx) {
-        var value = NodeUtil.getProperty(parent, propertyName);
-        if (value instanceof JFullSchema schema) {
-            dereferenceNode(schema, ctx);
-        }
-    }
-
-    private void dereferenceSchemaList(Node parent, String propertyName, DereferenceContext ctx) {
-        var value = NodeUtil.getProperty(parent, propertyName);
-        if (value instanceof List<?> list) {
-            for (var item : list) {
-                if (item instanceof JFullSchema schema) {
-                    dereferenceNode(schema, ctx);
-                } else if (item instanceof JsonSchema union && union.isFullSchema()) {
-                    dereferenceNode(union.asFullSchema(), ctx);
+            @Override
+            public void afterVisitFullSchema(JFullSchema n) {
+                if (n != node) {
+                    dereferenceNode(n, ctx);
                 }
             }
-        }
-    }
-
-    private void dereferenceSchemaMap(Node parent, String propertyName, DereferenceContext ctx) {
-        var value = NodeUtil.getProperty(parent, propertyName);
-        if (value instanceof Map<?, ?> map) {
-            for (var entry : map.values()) {
-                if (entry instanceof JFullSchema schema) {
-                    dereferenceNode(schema, ctx);
-                } else if (entry instanceof JsonSchema union && union.isFullSchema()) {
-                    dereferenceNode(union.asFullSchema(), ctx);
-                }
-            }
-        }
+        }, TraverserDirection.down);
     }
 
     private void handleUnresolvable(String ref, DereferenceContext ctx) {

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractVisitorStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/AbstractVisitorStage.java
@@ -52,38 +52,31 @@ public abstract class AbstractVisitorStage extends AbstractJavaStage {
                 .collect(Collectors.toList());
     }
 
-    protected List<MethodSource<?>> getBeforeAfterMethodsOnly(VisitorModel visitor) {
+    protected List<MethodSource<?>> getAfterVisitMethodsOnly(VisitorModel visitor) {
         return getAllMethodsForVisitorInterface(visitor).stream()
-                .filter(m -> m.getName().startsWith("beforeVisit") || m.getName().startsWith("afterVisit"))
+                .filter(m -> m.getName().startsWith("afterVisit"))
                 .collect(Collectors.toList());
     }
 
-    protected void addBeforeAfterImplementations(org.jboss.forge.roaster.model.source.JavaClassSource classSource,
-                                                  VisitorModel visitor) {
+    protected void addAfterVisitImplementations(org.jboss.forge.roaster.model.source.JavaClassSource classSource,
+                                                 VisitorModel visitor) {
         Set<String> methodNames = new HashSet<>();
-        for (MethodSource<?> method : getBeforeAfterMethodsOnly(visitor)) {
+        for (MethodSource<?> method : getAfterVisitMethodsOnly(visitor)) {
             if (methodNames.contains(method.getName())) {
                 continue;
             }
             methodNames.add(method.getName());
 
-            boolean isBefore = method.getName().startsWith("beforeVisit");
             org.jboss.forge.roaster.model.source.ParameterSource<?> param = method.getParameters().get(0);
             classSource.addImport(param.getType());
 
             MethodSource<org.jboss.forge.roaster.model.source.JavaClassSource> methodSource = classSource.addMethod()
                     .setName(method.getName())
+                    .setReturnTypeVoid()
                     .setPublic();
             methodSource.addParameter(param.getType().getSimpleName(), param.getName());
             methodSource.addAnnotation(Override.class);
-
-            if (isBefore) {
-                methodSource.setReturnType(boolean.class);
-                methodSource.setBody("return true;");
-            } else {
-                methodSource.setReturnTypeVoid();
-                methodSource.setBody("");
-            }
+            methodSource.setBody("");
         }
     }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateAllNodeVisitorStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateAllNodeVisitorStage.java
@@ -83,39 +83,29 @@ public class CreateAllNodeVisitorStage extends AbstractVisitorStage {
                 .setReturnTypeVoid().setProtected().setAbstract(true);
         visitNodeMethod.addParameter("Node", "node");
 
-        // Create beforeVisitNode / afterVisitNode hooks
-        MethodSource<JavaClassSource> beforeMethod = allNodeVisitorSource.addMethod().setName("beforeVisitNode")
-                .setReturnType(boolean.class).setProtected();
-        beforeMethod.addParameter("Node", "node");
-        beforeMethod.setBody("return true;");
-
+        // Create afterVisitNode hook
         MethodSource<JavaClassSource> afterMethod = allNodeVisitorSource.addMethod().setName("afterVisitNode")
                 .setReturnTypeVoid().setProtected();
         afterMethod.addParameter("Node", "node");
         afterMethod.setBody("");
 
-        // Now create an implementation for each visit/beforeVisit/afterVisit method.
+        // Now create an implementation for each visit/afterVisit method.
         methodsToImplement.forEach(method -> {
             String name = method.getName();
-            boolean isBefore = name.startsWith("beforeVisit");
             boolean isAfter = name.startsWith("afterVisit");
 
             MethodSource<JavaClassSource> methodSource = allNodeVisitorSource.addMethod()
                     .setName(name)
+                    .setReturnTypeVoid()
                     .setPublic();
             ParameterSource<?> param = method.getParameters().get(0);
             allNodeVisitorSource.addImport(param.getType());
             methodSource.addParameter(param.getType().getSimpleName(), param.getName());
             methodSource.addAnnotation(Override.class);
 
-            if (isBefore) {
-                methodSource.setReturnType(boolean.class);
-                methodSource.setBody("return this.beforeVisitNode(node);");
-            } else if (isAfter) {
-                methodSource.setReturnTypeVoid();
+            if (isAfter) {
                 methodSource.setBody("this.afterVisitNode(node);");
             } else {
-                methodSource.setReturnTypeVoid();
                 methodSource.setBody("this.visitNode(node);");
             }
         });

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonerDispatchersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateClonerDispatchersStage.java
@@ -130,7 +130,7 @@ public class CreateClonerDispatchersStage extends AbstractVisitorStage {
             methodSource.setBody(body.toString());
         });
 
-        addBeforeAfterImplementations(dispatcherSource, visitor);
+        addAfterVisitImplementations(dispatcherSource, visitor);
         getState().getJavaIndex().index(dispatcherSource);
     }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReaderDispatchersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateReaderDispatchersStage.java
@@ -121,7 +121,7 @@ public class CreateReaderDispatchersStage extends AbstractVisitorStage {
         });
 
         // Index the new class
-        addBeforeAfterImplementations(readerDispatcherSource, visitor);
+        addAfterVisitImplementations(readerDispatcherSource, visitor);
         getState().getJavaIndex().index(readerDispatcherSource);
     }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateTraversersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateTraversersStage.java
@@ -54,6 +54,7 @@ public class CreateTraversersStage extends AbstractVisitorStage {
         JavaClassSource abstractTraverserSource = getState().getJavaIndex().lookupClass(getAbstractTraverserFQN());
         traverserSource.addImport(abstractTraverserSource);
         traverserSource.extendSuperType(abstractTraverserSource);
+        traverserSource.addImport(getState().getConfig().getRootNamespace() + ".visitors.TraversalAction");
 
         // Create the constructor
         JavaInterfaceSource rootVisitorJavaInterface = getState().getJavaIndex().lookupInterface(getRootVisitorInterfaceFQN());
@@ -108,30 +109,8 @@ public class CreateTraversersStage extends AbstractVisitorStage {
             methodSource.setBody(body);
         });
 
-        // Also implement beforeVisit/afterVisit by delegating to the user's visitor
-        methodsToImplement.forEach(method -> {
-            String entityName = method.getName().replace("visit", "");
-            ParameterSource<?> param = method.getParameters().get(0);
-            String paramType = param.getType().getSimpleName();
-
-            // beforeVisitXyz
-            MethodSource<JavaClassSource> beforeMethod = traverserSource.addMethod()
-                    .setName("beforeVisit" + entityName)
-                    .setReturnType(boolean.class)
-                    .setPublic();
-            beforeMethod.addParameter(paramType, param.getName());
-            beforeMethod.addAnnotation(Override.class);
-            beforeMethod.setBody("return true;");
-
-            // afterVisitXyz
-            MethodSource<JavaClassSource> afterMethod = traverserSource.addMethod()
-                    .setName("afterVisit" + entityName)
-                    .setReturnTypeVoid()
-                    .setPublic();
-            afterMethod.addParameter(paramType, param.getName());
-            afterMethod.addAnnotation(Override.class);
-            afterMethod.setBody("");
-        });
+        // Add afterVisit implementations (no-ops on the traverser itself)
+        addAfterVisitImplementations(traverserSource, visitor);
 
         // Index the new class
         getState().getJavaIndex().index(traverserSource);
@@ -144,9 +123,11 @@ public class CreateTraversersStage extends AbstractVisitorStage {
 
         body.addContext("entityName", entityModel.getName());
         body.addContext("visitorType", visitorTypeName);
-        body.append("if (((${visitorType}) this.visitor).beforeVisit${entityName}(node)) {");
 
+        // Call visitXyz, then check if the visitor requested skip via the context
+        body.append("this.traversalContext.resetAction();");
         body.append("node.accept(this.visitor);");
+        body.append("if (this.traversalContext.consumeAction() != TraversalAction.SKIP) {");
 
         Collection<PropertyModel> allProperties = getState().getConceptIndex().getAllEntityProperties(entityModel).stream().map(property -> property.getProperty()).filter(property -> {
             return isEntity(property) || isEntityList(property) || isEntityMap(property)

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateVisitorAdaptersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateVisitorAdaptersStage.java
@@ -96,18 +96,11 @@ public class CreateVisitorAdaptersStage extends AbstractVisitorStage {
 
         // Now create an empty implementation for each visit method.
         methodsToImplement.forEach(method -> {
-            boolean isBooleanReturn = method.getName().startsWith("beforeVisit");
-
             MethodSource<JavaClassSource> methodSource = visitorAdapterSource.addMethod()
                     .setName(method.getName())
+                    .setReturnTypeVoid()
                     .setPublic();
-            if (isBooleanReturn) {
-                methodSource.setReturnType(boolean.class);
-                methodSource.setBody("return true;");
-            } else {
-                methodSource.setReturnTypeVoid();
-                methodSource.setBody("");
-            }
+            methodSource.setBody("");
             // We know each visit method will have a single parameter.
             ParameterSource<?> param = method.getParameters().get(0);
             visitorAdapterSource.addImport(param.getType());

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateVisitorInterfacesStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateVisitorInterfacesStage.java
@@ -44,10 +44,11 @@ public class CreateVisitorInterfacesStage extends AbstractVisitorStage {
             visitorInterfaceSource.addInterface(parentVisitorInterface.getName());
         }
 
-        // Now create visitXyz, beforeVisitXyz, and afterVisitXyz methods for each entity
+        // visitXyz is the main callback, called by the traverser for each node.
+        // The visitor can call TraversalContext.skip() to prevent auto-recursion.
+        // afterVisitXyz is called after children are traversed (or skipped).
         visitor.getEntities().forEach(entity -> {
             createVisitMethodFor(visitorInterfaceSource, entity);
-            createBeforeVisitMethodFor(visitorInterfaceSource, entity);
             createAfterVisitMethodFor(visitorInterfaceSource, entity);
         });
 
@@ -59,12 +60,6 @@ public class CreateVisitorInterfacesStage extends AbstractVisitorStage {
         });
     }
 
-    // visitXyz is the main visitor callback, called by node.accept(visitor).
-    // It is separate from beforeVisitXyz to keep backward compatibility (void return)
-    // and because the traversal gate (before) and the work (visit) are separate concerns
-    // for the regular visitor. If in the future we want to merge them (like the DiffVisitor's
-    // boolean visitXyz pattern), we would change visitXyz to return boolean and remove
-    // beforeVisitXyz.
     private void createVisitMethodFor(JavaInterfaceSource visitorInterfaceSource, EntityModel entity) {
         String visitMethodName = "visit" + entity.getName();
 
@@ -79,21 +74,6 @@ public class CreateVisitorInterfacesStage extends AbstractVisitorStage {
         MethodSource<JavaInterfaceSource> methodSource = visitorInterfaceSource.addMethod()
                 .setName(visitMethodName)
                 .setReturnTypeVoid()
-                .setPublic();
-        methodSource.addParameter(javaEntityModel.getName(), "node");
-    }
-
-    private void createBeforeVisitMethodFor(JavaInterfaceSource visitorInterfaceSource, EntityModel entity) {
-        String methodName = "beforeVisit" + entity.getName();
-
-        JavaInterfaceSource javaEntityModel = findRootJavaEntity(entity);
-        if (javaEntityModel == null) {
-            return;
-        }
-
-        MethodSource<JavaInterfaceSource> methodSource = visitorInterfaceSource.addMethod()
-                .setName(methodName)
-                .setReturnType(boolean.class)
                 .setPublic();
         methodSource.addParameter(javaEntityModel.getName(), "node");
     }

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWriterDispatchersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateWriterDispatchersStage.java
@@ -121,7 +121,7 @@ public class CreateWriterDispatchersStage extends AbstractVisitorStage {
         });
 
         // Index the new class
-        addBeforeAfterImplementations(writerDispatcherSource, visitor);
+        addAfterVisitImplementations(writerDispatcherSource, visitor);
         getState().getJavaIndex().index(writerDispatcherSource);
     }
 

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/LoadBaseClassesStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/LoadBaseClassesStage.java
@@ -25,6 +25,7 @@ public class LoadBaseClassesStage extends AbstractStage {
         try {
             loadBaseEnums(
                     "io.apitomy.umg.base.visitors.TraversalStepType",
+                    "io.apitomy.umg.base.visitors.TraversalAction",
                     "io.apitomy.umg.base.ParentPropertyType"
                     );
             loadBaseClasses(

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/TraversalAction.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/TraversalAction.java
@@ -1,0 +1,19 @@
+package io.apitomy.umg.base.visitors;
+
+/**
+ * Action that a visitor can request during traversal via the
+ * {@link TraversalContext}. The traverser checks the action after
+ * calling each visit method and acts accordingly.
+ */
+public enum TraversalAction {
+    /**
+     * Continue with normal traversal — visit children recursively.
+     * This is the default if the visitor does not request an action.
+     */
+    CONTINUE,
+
+    /**
+     * Skip traversal of children for the current node.
+     */
+    SKIP
+}

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/TraversalContext.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/TraversalContext.java
@@ -3,19 +3,56 @@ package io.apitomy.umg.base.visitors;
 import java.util.List;
 
 /**
- * Context used during traversal of a model. This gives insight into where in
- * the traversal of a model a visitor/traverser might be. The traverser
- * maintains this context and optionally makes it available to the visitor (only
- * if the visitor implements the TraversingVisitor interface.
+ * Context available during model traversal, providing path information
+ * and traversal control.
+ * <p>
+ * The traverser maintains this context and makes it available to the visitor
+ * if the visitor implements {@link TraversingVisitor}. Visitors can use it to:
+ * <ul>
+ *   <li>Inspect the current traversal path ({@link #getAllSteps()},
+ *       {@link #getMostRecentStep()})</li>
+ *   <li>Control traversal behavior ({@link #skip()} to prevent auto-recursion
+ *       into the current node's children)</li>
+ * </ul>
+ * <p>
+ * The traverser resets the action to {@link TraversalAction#CONTINUE} before
+ * each visit method call, so visitors only need to call {@link #skip()} when
+ * they want non-default behavior.
  */
 public interface TraversalContext {
 
+    /**
+     * Returns the most recent traversal step (the current position).
+     */
     public TraversalStep getMostRecentStep();
 
+    /**
+     * Returns all traversal steps from root to the current position.
+     */
     public List<TraversalStep> getAllSteps();
 
+    /**
+     * Returns {@code true} if the traversal path contains a step of the
+     * given type and value.
+     */
     public boolean containsStep(TraversalStepType type, Object value);
 
+    /**
+     * Returns the name of the most recent property step in the traversal path,
+     * or {@code null} if no property step exists.
+     */
     public String getMostRecentPropertyStep();
+
+    /**
+     * Request that the traverser skip auto-recursion into the current node's
+     * children. Call this from a visit method to handle recursion manually
+     * or to stop traversal at this level.
+     * <p>
+     * The action resets to {@link TraversalAction#CONTINUE} before each
+     * visit method call — only call this when you want to override the default.
+     * <p>
+     * The {@code afterVisit} callback is still called even when skipping.
+     */
+    public void skip();
 
 }

--- a/generator/src/main/resources/base/io/apitomy/umg/base/visitors/TraversalContextImpl.java
+++ b/generator/src/main/resources/base/io/apitomy/umg/base/visitors/TraversalContextImpl.java
@@ -16,6 +16,7 @@ import java.util.Stack;
 public class TraversalContextImpl implements TraversalContext {
 
     private final Stack<TraversalStep> stack = new Stack<>();
+    private TraversalAction action = TraversalAction.CONTINUE;
 
     public void pushProperty(String propertyName) {
         this.stack.push(TraversalStep.fromNodeProperty(propertyName));
@@ -65,6 +66,29 @@ public class TraversalContextImpl implements TraversalContext {
             }
         }
         return false;
+    }
+
+    @Override
+    public void skip() {
+        this.action = TraversalAction.SKIP;
+    }
+
+    /**
+     * Resets the action to {@link TraversalAction#CONTINUE}. Called by the
+     * traverser before each visit method.
+     */
+    public void resetAction() {
+        this.action = TraversalAction.CONTINUE;
+    }
+
+    /**
+     * Returns the current action and resets to CONTINUE. Called by the
+     * traverser after each visit method.
+     */
+    public TraversalAction consumeAction() {
+        TraversalAction current = this.action;
+        this.action = TraversalAction.CONTINUE;
+        return current;
     }
 
 }

--- a/generator/src/test/resources/io/apitomy/umg/full/expected-manifest.txt
+++ b/generator/src/test/resources/io/apitomy/umg/full/expected-manifest.txt
@@ -1421,6 +1421,7 @@ io/apitomy/datamodels/models/visitors/AllNodeVisitor.java
 io/apitomy/datamodels/models/visitors/CombinedVisitor.java
 io/apitomy/datamodels/models/visitors/CombinedVisitorAdapter.java
 io/apitomy/datamodels/models/visitors/ReverseTraverser.java
+io/apitomy/datamodels/models/visitors/TraversalAction.java
 io/apitomy/datamodels/models/visitors/TraversalContext.java
 io/apitomy/datamodels/models/visitors/TraversalContextImpl.java
 io/apitomy/datamodels/models/visitors/TraversalStep.java

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelClonerDispatcher.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelClonerDispatcher.java
@@ -77,17 +77,7 @@ public class Syn1ModelClonerDispatcher implements Syn1Visitor, ModelCloner {
 	}
 
 	@Override
-	public boolean beforeVisitPaths(SynPaths node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPaths(SynPaths node) {
-	}
-
-	@Override
-	public boolean beforeVisitOperation(SynOperation node) {
-		return true;
 	}
 
 	@Override
@@ -95,17 +85,7 @@ public class Syn1ModelClonerDispatcher implements Syn1Visitor, ModelCloner {
 	}
 
 	@Override
-	public boolean beforeVisitSchema(SynSchema node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitSchema(SynSchema node) {
-	}
-
-	@Override
-	public boolean beforeVisitInfo(SynInfo node) {
-		return true;
 	}
 
 	@Override
@@ -113,17 +93,7 @@ public class Syn1ModelClonerDispatcher implements Syn1Visitor, ModelCloner {
 	}
 
 	@Override
-	public boolean beforeVisitPathItem(SynPathItem node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPathItem(SynPathItem node) {
-	}
-
-	@Override
-	public boolean beforeVisitDocument(SynDocument node) {
-		return true;
 	}
 
 	@Override
@@ -131,17 +101,7 @@ public class Syn1ModelClonerDispatcher implements Syn1Visitor, ModelCloner {
 	}
 
 	@Override
-	public boolean beforeVisitContact(SynContact node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitContact(SynContact node) {
-	}
-
-	@Override
-	public boolean beforeVisitItem(SynItem node) {
-		return true;
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReaderDispatcher.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelReaderDispatcher.java
@@ -70,17 +70,7 @@ public class Syn1ModelReaderDispatcher implements Syn1Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitPaths(SynPaths node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPaths(SynPaths node) {
-	}
-
-	@Override
-	public boolean beforeVisitOperation(SynOperation node) {
-		return true;
 	}
 
 	@Override
@@ -88,17 +78,7 @@ public class Syn1ModelReaderDispatcher implements Syn1Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitSchema(SynSchema node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitSchema(SynSchema node) {
-	}
-
-	@Override
-	public boolean beforeVisitInfo(SynInfo node) {
-		return true;
 	}
 
 	@Override
@@ -106,17 +86,7 @@ public class Syn1ModelReaderDispatcher implements Syn1Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitPathItem(SynPathItem node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPathItem(SynPathItem node) {
-	}
-
-	@Override
-	public boolean beforeVisitDocument(SynDocument node) {
-		return true;
 	}
 
 	@Override
@@ -124,17 +94,7 @@ public class Syn1ModelReaderDispatcher implements Syn1Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitContact(SynContact node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitContact(SynContact node) {
-	}
-
-	@Override
-	public boolean beforeVisitItem(SynItem node) {
-		return true;
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelWriterDispatcher.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/io/Syn1ModelWriterDispatcher.java
@@ -70,17 +70,7 @@ public class Syn1ModelWriterDispatcher implements Syn1Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitPaths(SynPaths node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPaths(SynPaths node) {
-	}
-
-	@Override
-	public boolean beforeVisitOperation(SynOperation node) {
-		return true;
 	}
 
 	@Override
@@ -88,17 +78,7 @@ public class Syn1ModelWriterDispatcher implements Syn1Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitSchema(SynSchema node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitSchema(SynSchema node) {
-	}
-
-	@Override
-	public boolean beforeVisitInfo(SynInfo node) {
-		return true;
 	}
 
 	@Override
@@ -106,17 +86,7 @@ public class Syn1ModelWriterDispatcher implements Syn1Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitPathItem(SynPathItem node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPathItem(SynPathItem node) {
-	}
-
-	@Override
-	public boolean beforeVisitDocument(SynDocument node) {
-		return true;
 	}
 
 	@Override
@@ -124,17 +94,7 @@ public class Syn1ModelWriterDispatcher implements Syn1Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitContact(SynContact node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitContact(SynContact node) {
-	}
-
-	@Override
-	public boolean beforeVisitItem(SynItem node) {
-		return true;
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1Traverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1Traverser.java
@@ -16,6 +16,7 @@ import io.test.synthetic.v1.Syn1PathItem;
 import io.test.synthetic.v1.Syn1Paths;
 import io.test.synthetic.v1.Syn1Schema;
 import io.test.synthetic.visitors.AbstractTraverser;
+import io.test.synthetic.visitors.TraversalAction;
 import io.test.synthetic.visitors.Visitor;
 
 public class Syn1Traverser extends AbstractTraverser implements Syn1Visitor {
@@ -26,8 +27,9 @@ public class Syn1Traverser extends AbstractTraverser implements Syn1Visitor {
 
 	@Override
 	public void visitPaths(SynPaths node) {
-		if (((Syn1Visitor) this.visitor).beforeVisitPaths(node)) {
-			node.accept(this.visitor);
+		this.traversalContext.resetAction();
+		node.accept(this.visitor);
+		if (this.traversalContext.consumeAction() != TraversalAction.SKIP) {
 			Syn1Paths model = (Syn1Paths) node;
 			this.traverseMappedNode(model);
 		}
@@ -36,8 +38,9 @@ public class Syn1Traverser extends AbstractTraverser implements Syn1Visitor {
 
 	@Override
 	public void visitOperation(SynOperation node) {
-		if (((Syn1Visitor) this.visitor).beforeVisitOperation(node)) {
-			node.accept(this.visitor);
+		this.traversalContext.resetAction();
+		node.accept(this.visitor);
+		if (this.traversalContext.consumeAction() != TraversalAction.SKIP) {
 			Syn1Operation model = (Syn1Operation) node;
 			this.traverseList("parameters", model.getParameters());
 		}
@@ -46,8 +49,9 @@ public class Syn1Traverser extends AbstractTraverser implements Syn1Visitor {
 
 	@Override
 	public void visitSchema(SynSchema node) {
-		if (((Syn1Visitor) this.visitor).beforeVisitSchema(node)) {
-			node.accept(this.visitor);
+		this.traversalContext.resetAction();
+		node.accept(this.visitor);
+		if (this.traversalContext.consumeAction() != TraversalAction.SKIP) {
 			Syn1Schema model = (Syn1Schema) node;
 			this.traverseUnion("items", model.getItems());
 			this.traverseMap("properties", model.getProperties());
@@ -61,8 +65,9 @@ public class Syn1Traverser extends AbstractTraverser implements Syn1Visitor {
 
 	@Override
 	public void visitInfo(SynInfo node) {
-		if (((Syn1Visitor) this.visitor).beforeVisitInfo(node)) {
-			node.accept(this.visitor);
+		this.traversalContext.resetAction();
+		node.accept(this.visitor);
+		if (this.traversalContext.consumeAction() != TraversalAction.SKIP) {
 			Syn1Info model = (Syn1Info) node;
 			this.traverseNode("contact", model.getContact());
 		}
@@ -71,8 +76,9 @@ public class Syn1Traverser extends AbstractTraverser implements Syn1Visitor {
 
 	@Override
 	public void visitPathItem(SynPathItem node) {
-		if (((Syn1Visitor) this.visitor).beforeVisitPathItem(node)) {
-			node.accept(this.visitor);
+		this.traversalContext.resetAction();
+		node.accept(this.visitor);
+		if (this.traversalContext.consumeAction() != TraversalAction.SKIP) {
 			Syn1PathItem model = (Syn1PathItem) node;
 			this.traverseNode("get", model.getGet());
 			this.traverseNode("put", model.getPut());
@@ -83,8 +89,9 @@ public class Syn1Traverser extends AbstractTraverser implements Syn1Visitor {
 
 	@Override
 	public void visitDocument(SynDocument node) {
-		if (((Syn1Visitor) this.visitor).beforeVisitDocument(node)) {
-			node.accept(this.visitor);
+		this.traversalContext.resetAction();
+		node.accept(this.visitor);
+		if (this.traversalContext.consumeAction() != TraversalAction.SKIP) {
 			Syn1Document model = (Syn1Document) node;
 			this.traverseNode("info", model.getInfo());
 			this.traverseList("items", model.getItems());
@@ -95,16 +102,18 @@ public class Syn1Traverser extends AbstractTraverser implements Syn1Visitor {
 
 	@Override
 	public void visitContact(SynContact node) {
-		if (((Syn1Visitor) this.visitor).beforeVisitContact(node)) {
-			node.accept(this.visitor);
+		this.traversalContext.resetAction();
+		node.accept(this.visitor);
+		if (this.traversalContext.consumeAction() != TraversalAction.SKIP) {
 		}
 		((Syn1Visitor) this.visitor).afterVisitContact(node);
 	}
 
 	@Override
 	public void visitItem(SynItem node) {
-		if (((Syn1Visitor) this.visitor).beforeVisitItem(node)) {
-			node.accept(this.visitor);
+		this.traversalContext.resetAction();
+		node.accept(this.visitor);
+		if (this.traversalContext.consumeAction() != TraversalAction.SKIP) {
 			Syn1Item model = (Syn1Item) node;
 			this.traverseNode("schema", model.getSchema());
 			this.traverseUnion("defaultValue", model.getDefaultValue());
@@ -113,17 +122,7 @@ public class Syn1Traverser extends AbstractTraverser implements Syn1Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitPaths(SynPaths node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPaths(SynPaths node) {
-	}
-
-	@Override
-	public boolean beforeVisitOperation(SynOperation node) {
-		return true;
 	}
 
 	@Override
@@ -131,17 +130,7 @@ public class Syn1Traverser extends AbstractTraverser implements Syn1Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitSchema(SynSchema node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitSchema(SynSchema node) {
-	}
-
-	@Override
-	public boolean beforeVisitInfo(SynInfo node) {
-		return true;
 	}
 
 	@Override
@@ -149,17 +138,7 @@ public class Syn1Traverser extends AbstractTraverser implements Syn1Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitPathItem(SynPathItem node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPathItem(SynPathItem node) {
-	}
-
-	@Override
-	public boolean beforeVisitDocument(SynDocument node) {
-		return true;
 	}
 
 	@Override
@@ -167,17 +146,7 @@ public class Syn1Traverser extends AbstractTraverser implements Syn1Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitContact(SynContact node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitContact(SynContact node) {
-	}
-
-	@Override
-	public boolean beforeVisitItem(SynItem node) {
-		return true;
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1VisitorAdapter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1VisitorAdapter.java
@@ -16,21 +16,11 @@ public class Syn1VisitorAdapter implements Syn1Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitPaths(SynPaths node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPaths(SynPaths node) {
 	}
 
 	@Override
 	public void visitOperation(SynOperation node) {
-	}
-
-	@Override
-	public boolean beforeVisitOperation(SynOperation node) {
-		return true;
 	}
 
 	@Override
@@ -42,21 +32,11 @@ public class Syn1VisitorAdapter implements Syn1Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitSchema(SynSchema node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitSchema(SynSchema node) {
 	}
 
 	@Override
 	public void visitInfo(SynInfo node) {
-	}
-
-	@Override
-	public boolean beforeVisitInfo(SynInfo node) {
-		return true;
 	}
 
 	@Override
@@ -68,21 +48,11 @@ public class Syn1VisitorAdapter implements Syn1Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitPathItem(SynPathItem node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPathItem(SynPathItem node) {
 	}
 
 	@Override
 	public void visitDocument(SynDocument node) {
-	}
-
-	@Override
-	public boolean beforeVisitDocument(SynDocument node) {
-		return true;
 	}
 
 	@Override
@@ -94,21 +64,11 @@ public class Syn1VisitorAdapter implements Syn1Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitContact(SynContact node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitContact(SynContact node) {
 	}
 
 	@Override
 	public void visitItem(SynItem node) {
-	}
-
-	@Override
-	public boolean beforeVisitItem(SynItem node) {
-		return true;
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelClonerDispatcher.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelClonerDispatcher.java
@@ -77,17 +77,7 @@ public class Syn2ModelClonerDispatcher implements Syn2Visitor, ModelCloner {
 	}
 
 	@Override
-	public boolean beforeVisitPaths(SynPaths node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPaths(SynPaths node) {
-	}
-
-	@Override
-	public boolean beforeVisitOperation(SynOperation node) {
-		return true;
 	}
 
 	@Override
@@ -95,17 +85,7 @@ public class Syn2ModelClonerDispatcher implements Syn2Visitor, ModelCloner {
 	}
 
 	@Override
-	public boolean beforeVisitSchema(SynSchema node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitSchema(SynSchema node) {
-	}
-
-	@Override
-	public boolean beforeVisitInfo(SynInfo node) {
-		return true;
 	}
 
 	@Override
@@ -113,17 +93,7 @@ public class Syn2ModelClonerDispatcher implements Syn2Visitor, ModelCloner {
 	}
 
 	@Override
-	public boolean beforeVisitPathItem(SynPathItem node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPathItem(SynPathItem node) {
-	}
-
-	@Override
-	public boolean beforeVisitDocument(SynDocument node) {
-		return true;
 	}
 
 	@Override
@@ -131,17 +101,7 @@ public class Syn2ModelClonerDispatcher implements Syn2Visitor, ModelCloner {
 	}
 
 	@Override
-	public boolean beforeVisitContact(SynContact node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitContact(SynContact node) {
-	}
-
-	@Override
-	public boolean beforeVisitItem(SynItem node) {
-		return true;
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReaderDispatcher.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelReaderDispatcher.java
@@ -70,17 +70,7 @@ public class Syn2ModelReaderDispatcher implements Syn2Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitPaths(SynPaths node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPaths(SynPaths node) {
-	}
-
-	@Override
-	public boolean beforeVisitOperation(SynOperation node) {
-		return true;
 	}
 
 	@Override
@@ -88,17 +78,7 @@ public class Syn2ModelReaderDispatcher implements Syn2Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitSchema(SynSchema node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitSchema(SynSchema node) {
-	}
-
-	@Override
-	public boolean beforeVisitInfo(SynInfo node) {
-		return true;
 	}
 
 	@Override
@@ -106,17 +86,7 @@ public class Syn2ModelReaderDispatcher implements Syn2Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitPathItem(SynPathItem node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPathItem(SynPathItem node) {
-	}
-
-	@Override
-	public boolean beforeVisitDocument(SynDocument node) {
-		return true;
 	}
 
 	@Override
@@ -124,17 +94,7 @@ public class Syn2ModelReaderDispatcher implements Syn2Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitContact(SynContact node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitContact(SynContact node) {
-	}
-
-	@Override
-	public boolean beforeVisitItem(SynItem node) {
-		return true;
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelWriterDispatcher.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/io/Syn2ModelWriterDispatcher.java
@@ -70,17 +70,7 @@ public class Syn2ModelWriterDispatcher implements Syn2Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitPaths(SynPaths node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPaths(SynPaths node) {
-	}
-
-	@Override
-	public boolean beforeVisitOperation(SynOperation node) {
-		return true;
 	}
 
 	@Override
@@ -88,17 +78,7 @@ public class Syn2ModelWriterDispatcher implements Syn2Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitSchema(SynSchema node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitSchema(SynSchema node) {
-	}
-
-	@Override
-	public boolean beforeVisitInfo(SynInfo node) {
-		return true;
 	}
 
 	@Override
@@ -106,17 +86,7 @@ public class Syn2ModelWriterDispatcher implements Syn2Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitPathItem(SynPathItem node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPathItem(SynPathItem node) {
-	}
-
-	@Override
-	public boolean beforeVisitDocument(SynDocument node) {
-		return true;
 	}
 
 	@Override
@@ -124,17 +94,7 @@ public class Syn2ModelWriterDispatcher implements Syn2Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitContact(SynContact node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitContact(SynContact node) {
-	}
-
-	@Override
-	public boolean beforeVisitItem(SynItem node) {
-		return true;
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2Traverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2Traverser.java
@@ -16,6 +16,7 @@ import io.test.synthetic.v2.Syn2PathItem;
 import io.test.synthetic.v2.Syn2Paths;
 import io.test.synthetic.v2.Syn2Schema;
 import io.test.synthetic.visitors.AbstractTraverser;
+import io.test.synthetic.visitors.TraversalAction;
 import io.test.synthetic.visitors.Visitor;
 
 public class Syn2Traverser extends AbstractTraverser implements Syn2Visitor {
@@ -26,8 +27,9 @@ public class Syn2Traverser extends AbstractTraverser implements Syn2Visitor {
 
 	@Override
 	public void visitPaths(SynPaths node) {
-		if (((Syn2Visitor) this.visitor).beforeVisitPaths(node)) {
-			node.accept(this.visitor);
+		this.traversalContext.resetAction();
+		node.accept(this.visitor);
+		if (this.traversalContext.consumeAction() != TraversalAction.SKIP) {
 			Syn2Paths model = (Syn2Paths) node;
 			this.traverseMappedNode(model);
 		}
@@ -36,8 +38,9 @@ public class Syn2Traverser extends AbstractTraverser implements Syn2Visitor {
 
 	@Override
 	public void visitOperation(SynOperation node) {
-		if (((Syn2Visitor) this.visitor).beforeVisitOperation(node)) {
-			node.accept(this.visitor);
+		this.traversalContext.resetAction();
+		node.accept(this.visitor);
+		if (this.traversalContext.consumeAction() != TraversalAction.SKIP) {
 			Syn2Operation model = (Syn2Operation) node;
 			this.traverseList("parameters", model.getParameters());
 		}
@@ -46,8 +49,9 @@ public class Syn2Traverser extends AbstractTraverser implements Syn2Visitor {
 
 	@Override
 	public void visitSchema(SynSchema node) {
-		if (((Syn2Visitor) this.visitor).beforeVisitSchema(node)) {
-			node.accept(this.visitor);
+		this.traversalContext.resetAction();
+		node.accept(this.visitor);
+		if (this.traversalContext.consumeAction() != TraversalAction.SKIP) {
 			Syn2Schema model = (Syn2Schema) node;
 			this.traverseUnion("items", model.getItems());
 			this.traverseMap("properties", model.getProperties());
@@ -61,8 +65,9 @@ public class Syn2Traverser extends AbstractTraverser implements Syn2Visitor {
 
 	@Override
 	public void visitInfo(SynInfo node) {
-		if (((Syn2Visitor) this.visitor).beforeVisitInfo(node)) {
-			node.accept(this.visitor);
+		this.traversalContext.resetAction();
+		node.accept(this.visitor);
+		if (this.traversalContext.consumeAction() != TraversalAction.SKIP) {
 			Syn2Info model = (Syn2Info) node;
 			this.traverseNode("contact", model.getContact());
 		}
@@ -71,8 +76,9 @@ public class Syn2Traverser extends AbstractTraverser implements Syn2Visitor {
 
 	@Override
 	public void visitPathItem(SynPathItem node) {
-		if (((Syn2Visitor) this.visitor).beforeVisitPathItem(node)) {
-			node.accept(this.visitor);
+		this.traversalContext.resetAction();
+		node.accept(this.visitor);
+		if (this.traversalContext.consumeAction() != TraversalAction.SKIP) {
 			Syn2PathItem model = (Syn2PathItem) node;
 			this.traverseNode("get", model.getGet());
 			this.traverseNode("put", model.getPut());
@@ -84,8 +90,9 @@ public class Syn2Traverser extends AbstractTraverser implements Syn2Visitor {
 
 	@Override
 	public void visitDocument(SynDocument node) {
-		if (((Syn2Visitor) this.visitor).beforeVisitDocument(node)) {
-			node.accept(this.visitor);
+		this.traversalContext.resetAction();
+		node.accept(this.visitor);
+		if (this.traversalContext.consumeAction() != TraversalAction.SKIP) {
 			Syn2Document model = (Syn2Document) node;
 			this.traverseNode("info", model.getInfo());
 			this.traverseList("items", model.getItems());
@@ -97,16 +104,18 @@ public class Syn2Traverser extends AbstractTraverser implements Syn2Visitor {
 
 	@Override
 	public void visitContact(SynContact node) {
-		if (((Syn2Visitor) this.visitor).beforeVisitContact(node)) {
-			node.accept(this.visitor);
+		this.traversalContext.resetAction();
+		node.accept(this.visitor);
+		if (this.traversalContext.consumeAction() != TraversalAction.SKIP) {
 		}
 		((Syn2Visitor) this.visitor).afterVisitContact(node);
 	}
 
 	@Override
 	public void visitItem(SynItem node) {
-		if (((Syn2Visitor) this.visitor).beforeVisitItem(node)) {
-			node.accept(this.visitor);
+		this.traversalContext.resetAction();
+		node.accept(this.visitor);
+		if (this.traversalContext.consumeAction() != TraversalAction.SKIP) {
 			Syn2Item model = (Syn2Item) node;
 			this.traverseNode("schema", model.getSchema());
 			this.traverseUnion("defaultValue", model.getDefaultValue());
@@ -115,17 +124,7 @@ public class Syn2Traverser extends AbstractTraverser implements Syn2Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitPaths(SynPaths node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPaths(SynPaths node) {
-	}
-
-	@Override
-	public boolean beforeVisitOperation(SynOperation node) {
-		return true;
 	}
 
 	@Override
@@ -133,17 +132,7 @@ public class Syn2Traverser extends AbstractTraverser implements Syn2Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitSchema(SynSchema node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitSchema(SynSchema node) {
-	}
-
-	@Override
-	public boolean beforeVisitInfo(SynInfo node) {
-		return true;
 	}
 
 	@Override
@@ -151,17 +140,7 @@ public class Syn2Traverser extends AbstractTraverser implements Syn2Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitPathItem(SynPathItem node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPathItem(SynPathItem node) {
-	}
-
-	@Override
-	public boolean beforeVisitDocument(SynDocument node) {
-		return true;
 	}
 
 	@Override
@@ -169,17 +148,7 @@ public class Syn2Traverser extends AbstractTraverser implements Syn2Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitContact(SynContact node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitContact(SynContact node) {
-	}
-
-	@Override
-	public boolean beforeVisitItem(SynItem node) {
-		return true;
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2VisitorAdapter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2VisitorAdapter.java
@@ -16,21 +16,11 @@ public class Syn2VisitorAdapter implements Syn2Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitPaths(SynPaths node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPaths(SynPaths node) {
 	}
 
 	@Override
 	public void visitOperation(SynOperation node) {
-	}
-
-	@Override
-	public boolean beforeVisitOperation(SynOperation node) {
-		return true;
 	}
 
 	@Override
@@ -42,21 +32,11 @@ public class Syn2VisitorAdapter implements Syn2Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitSchema(SynSchema node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitSchema(SynSchema node) {
 	}
 
 	@Override
 	public void visitInfo(SynInfo node) {
-	}
-
-	@Override
-	public boolean beforeVisitInfo(SynInfo node) {
-		return true;
 	}
 
 	@Override
@@ -68,21 +48,11 @@ public class Syn2VisitorAdapter implements Syn2Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitPathItem(SynPathItem node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPathItem(SynPathItem node) {
 	}
 
 	@Override
 	public void visitDocument(SynDocument node) {
-	}
-
-	@Override
-	public boolean beforeVisitDocument(SynDocument node) {
-		return true;
 	}
 
 	@Override
@@ -94,21 +64,11 @@ public class Syn2VisitorAdapter implements Syn2Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitContact(SynContact node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitContact(SynContact node) {
 	}
 
 	@Override
 	public void visitItem(SynItem node) {
-	}
-
-	@Override
-	public boolean beforeVisitItem(SynItem node) {
-		return true;
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/AllNodeVisitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/AllNodeVisitor.java
@@ -14,21 +14,12 @@ public abstract class AllNodeVisitor implements CombinedVisitor {
 
 	protected abstract void visitNode(Node node);
 
-	protected boolean beforeVisitNode(Node node) {
-		return true;
-	}
-
 	protected void afterVisitNode(Node node) {
 	}
 
 	@Override
 	public void visitPaths(SynPaths node) {
 		this.visitNode(node);
-	}
-
-	@Override
-	public boolean beforeVisitPaths(SynPaths node) {
-		return this.beforeVisitNode(node);
 	}
 
 	@Override
@@ -42,11 +33,6 @@ public abstract class AllNodeVisitor implements CombinedVisitor {
 	}
 
 	@Override
-	public boolean beforeVisitOperation(SynOperation node) {
-		return this.beforeVisitNode(node);
-	}
-
-	@Override
 	public void afterVisitOperation(SynOperation node) {
 		this.afterVisitNode(node);
 	}
@@ -54,11 +40,6 @@ public abstract class AllNodeVisitor implements CombinedVisitor {
 	@Override
 	public void visitSchema(SynSchema node) {
 		this.visitNode(node);
-	}
-
-	@Override
-	public boolean beforeVisitSchema(SynSchema node) {
-		return this.beforeVisitNode(node);
 	}
 
 	@Override
@@ -72,11 +53,6 @@ public abstract class AllNodeVisitor implements CombinedVisitor {
 	}
 
 	@Override
-	public boolean beforeVisitInfo(SynInfo node) {
-		return this.beforeVisitNode(node);
-	}
-
-	@Override
 	public void afterVisitInfo(SynInfo node) {
 		this.afterVisitNode(node);
 	}
@@ -84,11 +60,6 @@ public abstract class AllNodeVisitor implements CombinedVisitor {
 	@Override
 	public void visitPathItem(SynPathItem node) {
 		this.visitNode(node);
-	}
-
-	@Override
-	public boolean beforeVisitPathItem(SynPathItem node) {
-		return this.beforeVisitNode(node);
 	}
 
 	@Override
@@ -102,11 +73,6 @@ public abstract class AllNodeVisitor implements CombinedVisitor {
 	}
 
 	@Override
-	public boolean beforeVisitDocument(SynDocument node) {
-		return this.beforeVisitNode(node);
-	}
-
-	@Override
 	public void afterVisitDocument(SynDocument node) {
 		this.afterVisitNode(node);
 	}
@@ -117,11 +83,6 @@ public abstract class AllNodeVisitor implements CombinedVisitor {
 	}
 
 	@Override
-	public boolean beforeVisitContact(SynContact node) {
-		return this.beforeVisitNode(node);
-	}
-
-	@Override
 	public void afterVisitContact(SynContact node) {
 		this.afterVisitNode(node);
 	}
@@ -129,11 +90,6 @@ public abstract class AllNodeVisitor implements CombinedVisitor {
 	@Override
 	public void visitItem(SynItem node) {
 		this.visitNode(node);
-	}
-
-	@Override
-	public boolean beforeVisitItem(SynItem node) {
-		return this.beforeVisitNode(node);
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/CombinedVisitorAdapter.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/CombinedVisitorAdapter.java
@@ -18,21 +18,11 @@ public class CombinedVisitorAdapter implements Syn2Visitor, Syn1Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitPaths(SynPaths node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPaths(SynPaths node) {
 	}
 
 	@Override
 	public void visitOperation(SynOperation node) {
-	}
-
-	@Override
-	public boolean beforeVisitOperation(SynOperation node) {
-		return true;
 	}
 
 	@Override
@@ -44,21 +34,11 @@ public class CombinedVisitorAdapter implements Syn2Visitor, Syn1Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitSchema(SynSchema node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitSchema(SynSchema node) {
 	}
 
 	@Override
 	public void visitInfo(SynInfo node) {
-	}
-
-	@Override
-	public boolean beforeVisitInfo(SynInfo node) {
-		return true;
 	}
 
 	@Override
@@ -70,21 +50,11 @@ public class CombinedVisitorAdapter implements Syn2Visitor, Syn1Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitPathItem(SynPathItem node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitPathItem(SynPathItem node) {
 	}
 
 	@Override
 	public void visitDocument(SynDocument node) {
-	}
-
-	@Override
-	public boolean beforeVisitDocument(SynDocument node) {
-		return true;
 	}
 
 	@Override
@@ -96,21 +66,11 @@ public class CombinedVisitorAdapter implements Syn2Visitor, Syn1Visitor {
 	}
 
 	@Override
-	public boolean beforeVisitContact(SynContact node) {
-		return true;
-	}
-
-	@Override
 	public void afterVisitContact(SynContact node) {
 	}
 
 	@Override
 	public void visitItem(SynItem node) {
-	}
-
-	@Override
-	public boolean beforeVisitItem(SynItem node) {
-		return true;
 	}
 
 	@Override

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/TraversalAction.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/TraversalAction.java
@@ -1,0 +1,19 @@
+package io.test.synthetic.visitors;
+
+/**
+ * Action that a visitor can request during traversal via the
+ * {@link TraversalContext}. The traverser checks the action after calling each
+ * visit method and acts accordingly.
+ */
+public enum TraversalAction {
+	/**
+	 * Continue with normal traversal — visit children recursively. This is the
+	 * default if the visitor does not request an action.
+	 */
+	CONTINUE,
+
+	/**
+	 * Skip traversal of children for the current node.
+	 */
+	SKIP
+}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/TraversalContext.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/TraversalContext.java
@@ -3,19 +3,56 @@ package io.test.synthetic.visitors;
 import java.util.List;
 
 /**
- * Context used during traversal of a model. This gives insight into where in
- * the traversal of a model a visitor/traverser might be. The traverser
- * maintains this context and optionally makes it available to the visitor (only
- * if the visitor implements the TraversingVisitor interface.
+ * Context available during model traversal, providing path information and
+ * traversal control.
+ * <p>
+ * The traverser maintains this context and makes it available to the visitor if
+ * the visitor implements {@link TraversingVisitor}. Visitors can use it to:
+ * <ul>
+ * <li>Inspect the current traversal path ({@link #getAllSteps()},
+ * {@link #getMostRecentStep()})</li>
+ * <li>Control traversal behavior ({@link #skip()} to prevent auto-recursion
+ * into the current node's children)</li>
+ * </ul>
+ * <p>
+ * The traverser resets the action to {@link TraversalAction#CONTINUE} before
+ * each visit method call, so visitors only need to call {@link #skip()} when
+ * they want non-default behavior.
  */
 public interface TraversalContext {
 
+	/**
+	 * Returns the most recent traversal step (the current position).
+	 */
 	public TraversalStep getMostRecentStep();
 
+	/**
+	 * Returns all traversal steps from root to the current position.
+	 */
 	public List<TraversalStep> getAllSteps();
 
+	/**
+	 * Returns {@code true} if the traversal path contains a step of the given type
+	 * and value.
+	 */
 	public boolean containsStep(TraversalStepType type, Object value);
 
+	/**
+	 * Returns the name of the most recent property step in the traversal path, or
+	 * {@code null} if no property step exists.
+	 */
 	public String getMostRecentPropertyStep();
+
+	/**
+	 * Request that the traverser skip auto-recursion into the current node's
+	 * children. Call this from a visit method to handle recursion manually or to
+	 * stop traversal at this level.
+	 * <p>
+	 * The action resets to {@link TraversalAction#CONTINUE} before each visit
+	 * method call — only call this when you want to override the default.
+	 * <p>
+	 * The {@code afterVisit} callback is still called even when skipping.
+	 */
+	public void skip();
 
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/TraversalContextImpl.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/TraversalContextImpl.java
@@ -16,6 +16,7 @@ import java.util.Stack;
 public class TraversalContextImpl implements TraversalContext {
 
 	private final Stack<TraversalStep> stack = new Stack<>();
+	private TraversalAction action = TraversalAction.CONTINUE;
 
 	public void pushProperty(String propertyName) {
 		this.stack.push(TraversalStep.fromNodeProperty(propertyName));
@@ -65,6 +66,29 @@ public class TraversalContextImpl implements TraversalContext {
 			}
 		}
 		return false;
+	}
+
+	@Override
+	public void skip() {
+		this.action = TraversalAction.SKIP;
+	}
+
+	/**
+	 * Resets the action to {@link TraversalAction#CONTINUE}. Called by the
+	 * traverser before each visit method.
+	 */
+	public void resetAction() {
+		this.action = TraversalAction.CONTINUE;
+	}
+
+	/**
+	 * Returns the current action and resets to CONTINUE. Called by the traverser
+	 * after each visit method.
+	 */
+	public TraversalAction consumeAction() {
+		TraversalAction current = this.action;
+		this.action = TraversalAction.CONTINUE;
+		return current;
 	}
 
 }

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/Visitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/visitors/Visitor.java
@@ -13,49 +13,33 @@ public interface Visitor {
 
 	public void visitPaths(SynPaths node);
 
-	public boolean beforeVisitPaths(SynPaths node);
-
 	public void afterVisitPaths(SynPaths node);
 
 	public void visitOperation(SynOperation node);
-
-	public boolean beforeVisitOperation(SynOperation node);
 
 	public void afterVisitOperation(SynOperation node);
 
 	public void visitSchema(SynSchema node);
 
-	public boolean beforeVisitSchema(SynSchema node);
-
 	public void afterVisitSchema(SynSchema node);
 
 	public void visitInfo(SynInfo node);
-
-	public boolean beforeVisitInfo(SynInfo node);
 
 	public void afterVisitInfo(SynInfo node);
 
 	public void visitPathItem(SynPathItem node);
 
-	public boolean beforeVisitPathItem(SynPathItem node);
-
 	public void afterVisitPathItem(SynPathItem node);
 
 	public void visitDocument(SynDocument node);
-
-	public boolean beforeVisitDocument(SynDocument node);
 
 	public void afterVisitDocument(SynDocument node);
 
 	public void visitContact(SynContact node);
 
-	public boolean beforeVisitContact(SynContact node);
-
 	public void afterVisitContact(SynContact node);
 
 	public void visitItem(SynItem node);
-
-	public boolean beforeVisitItem(SynItem node);
 
 	public void afterVisitItem(SynItem node);
 }


### PR DESCRIPTION
## Summary
Replace manual 24-property `dereferenceChildren` list with `VisitorUtil.visitTree` + `AllNodeVisitor` using `beforeVisitFullSchema`/`afterVisitFullSchema` callbacks from G13c.

- `beforeVisit` returns true for root (enter and enumerate children), false for children (don't recurse — dereferencer handles its own recursion)
- `afterVisit` calls `dereferenceNode` for each child schema
- Net -32 lines, eliminates property list maintenance burden

## Context
C41n in #1042, depends on G13c (#1185).

## Test plan
- [x] All 174 CC tests pass
- [x] All 8 dereferencer tests pass