### PR TITLE
feat(generator): unified context-based traversal control (G13d)

### DIFF
--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/CompoundSchemaDiffVisitor.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/CompoundSchemaDiffVisitor.java
@@ -102,13 +102,13 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     // -----------------------------------------------------------------------
 
     @Override
-    public boolean visitFullSchema(JCFullSchema original, JCFullSchema updated) {
+    public void visitFullSchema(JCFullSchema original, JCFullSchema updated) {
         // Store for cross-field logic
         this.currentOriginal = original;
         this.currentUpdated = updated;
 
         if (original == null || updated == null) {
-            return true;
+            return;
         }
 
         // If either side has a remaining $ref (cyclic back-edge or unresolved),
@@ -120,7 +120,7 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
             if (origRef != null && updRef != null && !origRef.equals(updRef)) {
                 ctx.addDifference(REFERENCE_TYPE_TARGET_SCHEMA_CHANGED, origRef, updRef);
             }
-            return false;
+            traversalContext.skip(); return;
         }
 
         var origTypeList = DiffUtil.getTypeList(original);
@@ -152,7 +152,7 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
                 } else {
                     ctx.addDifference(SUBSCHEMA_TYPE_CHANGED, origTypeList, updTypeList);
                 }
-                return false;
+                traversalContext.skip(); return;
             }
         } else if (originalType != null && updatedType != null && !originalType.equals(updatedType)) {
             if ("integer".equals(originalType) && "number".equals(updatedType)) {
@@ -162,11 +162,11 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
             } else {
                 ctx.addDifference(SUBSCHEMA_TYPE_CHANGED, originalType, updatedType);
             }
-            return false;
+            traversalContext.skip(); return;
         } else if (originalType != null && updatedType == null) {
             if (isEmptyOrTrueSchema(updated)) {
                 ctx.addDifference(SUBSCHEMA_TYPE_CHANGED_TO_EMPTY_OR_TRUE, originalType, "");
-                return false;
+                traversalContext.skip(); return;
             }
             var updAnyOf = updated.getAnyOf();
             var updOneOf = updated.getOneOf();
@@ -184,18 +184,18 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
                 }
                 if (origMatchesAny) {
                     ctx.addDifference(SUBSCHEMA_TYPE_CHANGED_TO_EMPTY_OR_TRUE, originalType, "anyOf/oneOf");
-                    return false;
+                    traversalContext.skip(); return;
                 }
             }
         } else if (originalType == null && updatedType != null) {
             if (isEmptyOrTrueSchema(original)) {
                 ctx.addDifference(SUBSCHEMA_TYPE_CHANGED, "", updatedType);
-                return false;
+                traversalContext.skip(); return;
             }
         }
 
         // Return true to let the traverser call all field-level diff methods
-        return true;
+        return;
     }
 
     private boolean isEmptyOrTrueSchema(JFullSchema schema) {
@@ -239,13 +239,13 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     // compatibility-based composition matching).
 
     @Override
-    public boolean visitFullSchemaProperty(JsonSchema original, JsonSchema updated) { return false; }
+    public void visitFullSchemaProperty(JsonSchema original, JsonSchema updated) { traversalContext.skip(); }
 
     @Override
-    public boolean visitFullSchemaPatternProperty(JsonSchema original, JsonSchema updated) { return false; }
+    public void visitFullSchemaPatternProperty(JsonSchema original, JsonSchema updated) { traversalContext.skip(); }
 
     @Override
-    public boolean visitFullSchemaDependentSchema(JsonSchema original, JsonSchema updated) {
+    public void visitFullSchemaDependentSchema(JsonSchema original, JsonSchema updated) {
         if (original != null && updated != null
                 && original.isFullSchema() && updated.isFullSchema()) {
             var subCtx = ctx.sub("dependentSchemas");
@@ -255,17 +255,17 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
                         original, updated);
             }
         }
-        return false;
+        traversalContext.skip(); return;
     }
 
     @Override
-    public boolean visitFullSchemaAllOfItem(JsonSchema original, JsonSchema updated) { return false; }
+    public void visitFullSchemaAllOfItem(JsonSchema original, JsonSchema updated) { traversalContext.skip(); }
 
     @Override
-    public boolean visitFullSchemaAnyOfItem(JsonSchema original, JsonSchema updated) { return false; }
+    public void visitFullSchemaAnyOfItem(JsonSchema original, JsonSchema updated) { traversalContext.skip(); }
 
     @Override
-    public boolean visitFullSchemaOneOfItem(JsonSchema original, JsonSchema updated) { return false; }
+    public void visitFullSchemaOneOfItem(JsonSchema original, JsonSchema updated) { traversalContext.skip(); }
 
     // -----------------------------------------------------------------------
     // String type fields
@@ -318,15 +318,15 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     // -----------------------------------------------------------------------
 
     @Override
-    public boolean diffFullSchemaMinimum(JCRangeValue original, JCRangeValue updated) {
-        if (original == null && updated == null) return false;
+    public void diffFullSchemaMinimum(JCRangeValue original, JCRangeValue updated) {
+        if (original == null && updated == null) { traversalContext.skip(); return; }
         if (original == null) {
             ctx.addDifference(NUMBER_TYPE_MINIMUM_ADDED, null, rangeToString(updated));
-            return false;
+            traversalContext.skip(); return;
         }
         if (updated == null) {
             ctx.addDifference(NUMBER_TYPE_MINIMUM_REMOVED, rangeToString(original), null);
-            return false;
+            traversalContext.skip(); return;
         }
         // Both present -- compare values
         Number origVal = original.getValue();
@@ -346,19 +346,19 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
             }
             // else: same value and exclusivity -- no diff
         }
-        return false; // don't auto-recurse into RangeValue fields
+        traversalContext.skip(); return; // don't auto-recurse into RangeValue fields
     }
 
     @Override
-    public boolean diffFullSchemaMaximum(JCRangeValue original, JCRangeValue updated) {
-        if (original == null && updated == null) return false;
+    public void diffFullSchemaMaximum(JCRangeValue original, JCRangeValue updated) {
+        if (original == null && updated == null) { traversalContext.skip(); return; }
         if (original == null) {
             ctx.addDifference(NUMBER_TYPE_MAXIMUM_ADDED, null, rangeToString(updated));
-            return false;
+            traversalContext.skip(); return;
         }
         if (updated == null) {
             ctx.addDifference(NUMBER_TYPE_MAXIMUM_REMOVED, rangeToString(original), null);
-            return false;
+            traversalContext.skip(); return;
         }
         // Both present -- compare values
         Number origVal = original.getValue();
@@ -378,7 +378,7 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
             }
             // else: same value and exclusivity -- no diff
         }
-        return false; // don't auto-recurse into RangeValue fields
+        traversalContext.skip(); return; // don't auto-recurse into RangeValue fields
     }
 
     @Override
@@ -418,10 +418,10 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     }
 
     @Override
-    public boolean diffFullSchemaItems(BooleanFullSchemaFullSchemaListUnion original,
+    public void diffFullSchemaItems(BooleanFullSchemaFullSchemaListUnion original,
                                     BooleanFullSchemaFullSchemaListUnion updated) {
         // After normalization, items is always a single schema or boolean (tuples → prefixItems)
-        if (original == null && updated == null) return false;
+        if (original == null && updated == null) { traversalContext.skip(); return; }
 
         if (original != null && updated != null) {
             if (original.isFullSchema() && updated.isFullSchema()) {
@@ -435,7 +435,7 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
             diffAddedRemoved(ctx, original, updated,
                     ARRAY_TYPE_ALL_ITEM_SCHEMA_ADDED, ARRAY_TYPE_ALL_ITEM_SCHEMA_REMOVED);
         }
-        return false;
+        traversalContext.skip(); return;
     }
 
     @Override
@@ -513,8 +513,8 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     }
 
     @Override
-    public boolean diffFullSchemaAdditionalItems(JsonSchema original, JsonSchema updated) {
-        if (original == null && updated == null) return false;
+    public void diffFullSchemaAdditionalItems(JsonSchema original, JsonSchema updated) {
+        if (original == null && updated == null) { traversalContext.skip(); return; }
 
         var origPermits = original == null || (original.isBoolean() ? original.asBoolean() : true);
         var updPermits = updated == null || (updated.isBoolean() ? updated.asBoolean() : true);
@@ -547,30 +547,30 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
         } else if ((original == null || (origIsBoolean && origPermits)) && updIsSchema) {
             ctx.addDifference(ARRAY_TYPE_ADDITIONAL_ITEMS_NARROWED, original, updated);
         }
-        return false;
+        traversalContext.skip(); return;
     }
 
     @Override
-    public boolean diffFullSchemaContains(JsonSchema original, JsonSchema updated) {
-        if (original == null && updated == null) return false;
+    public void diffFullSchemaContains(JsonSchema original, JsonSchema updated) {
+        if (original == null && updated == null) { traversalContext.skip(); return; }
         if (original == null) {
             ctx.addDifference(ARRAY_TYPE_CONTAINED_ITEM_SCHEMA_ADDED, null, updated);
-            return false;
+            traversalContext.skip(); return;
         }
         if (updated == null) {
             ctx.addDifference(ARRAY_TYPE_CONTAINED_ITEM_SCHEMA_REMOVED, original, null);
-            return false;
+            traversalContext.skip(); return;
         }
         var subCtx = ctx.sub("contains");
         if (!isUnionSchemaCompatible(subCtx, original, updated, true)) {
             subCtx.addDifference(ARRAY_TYPE_ITEM_SCHEMAS_CHANGED, original, updated);
         }
-        return false;
+        traversalContext.skip(); return;
     }
 
     @Override
-    public boolean diffFullSchemaUnevaluatedItems(JsonSchema original, JsonSchema updated) {
-        if (original == null && updated == null) return false;
+    public void diffFullSchemaUnevaluatedItems(JsonSchema original, JsonSchema updated) {
+        if (original == null && updated == null) { traversalContext.skip(); return; }
         if (original != null && updated != null
                 && original.isFullSchema() && updated.isFullSchema()) {
             if (isUnionSchemaCompatible(ctx, original, updated, true)) {
@@ -582,12 +582,12 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
             diffAddedRemoved(ctx, original, updated,
                     ARRAY_TYPE_ALL_ITEM_SCHEMA_ADDED, ARRAY_TYPE_ALL_ITEM_SCHEMA_REMOVED);
         }
-        return false;
+        traversalContext.skip(); return;
     }
 
     @Override
-    public boolean diffFullSchemaUnevaluatedProperties(JsonSchema original, JsonSchema updated) {
-        if (original == null && updated == null) return false;
+    public void diffFullSchemaUnevaluatedProperties(JsonSchema original, JsonSchema updated) {
+        if (original == null && updated == null) { traversalContext.skip(); return; }
         if (original != null && updated != null
                 && original.isFullSchema() && updated.isFullSchema()) {
             if (isUnionSchemaCompatible(ctx, original, updated, true)) {
@@ -600,7 +600,7 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
                     OBJECT_TYPE_ADDITIONAL_PROPERTIES_SCHEMA_ADDED,
                     OBJECT_TYPE_ADDITIONAL_PROPERTIES_SCHEMA_REMOVED);
         }
-        return false;
+        traversalContext.skip(); return;
     }
 
     // -----------------------------------------------------------------------
@@ -722,8 +722,8 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     }
 
     @Override
-    public boolean diffFullSchemaAdditionalProperties(JsonSchema original, JsonSchema updated) {
-        if (original == null && updated == null) return false;
+    public void diffFullSchemaAdditionalProperties(JsonSchema original, JsonSchema updated) {
+        if (original == null && updated == null) { traversalContext.skip(); return; }
 
         var origPermits = permitsAdditional(original);
         var updPermits = permitsAdditional(updated);
@@ -763,7 +763,7 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
                 ctx.addDifference(OBJECT_TYPE_ADDITIONAL_PROPERTIES_EXTENDED, original, updated);
             }
         }
-        return false;
+        traversalContext.skip(); return;
     }
 
     @Override
@@ -799,8 +799,8 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     }
 
     @Override
-    public boolean diffFullSchemaPropertyNames(JsonSchema original, JsonSchema updated) {
-        if (original == null && updated == null) return false;
+    public void diffFullSchemaPropertyNames(JsonSchema original, JsonSchema updated) {
+        if (original == null && updated == null) { traversalContext.skip(); return; }
         compareSchema(ctx, original, updated,
                 OBJECT_TYPE_PROPERTY_NAMES_SCHEMA_ADDED,
                 OBJECT_TYPE_PROPERTY_NAMES_SCHEMA_REMOVED,
@@ -808,7 +808,7 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
                 OBJECT_TYPE_PROPERTY_NAMES_SCHEMA_COMPATIBLE_BACKWARD_NOT_FORWARD,
                 OBJECT_TYPE_PROPERTY_NAMES_SCHEMA_COMPATIBLE_FORWARD_NOT_BACKWARD,
                 OBJECT_TYPE_PROPERTY_NAMES_SCHEMA_COMPATIBLE_NONE);
-        return false;
+        traversalContext.skip(); return;
     }
 
     // dependencies is always empty after conversion — d4-d7 entries are split
@@ -1038,15 +1038,15 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     // -----------------------------------------------------------------------
 
     @Override
-    public boolean diffFullSchemaNot(JsonSchema original, JsonSchema updated) {
-        if (original == null && updated == null) return false;
+    public void diffFullSchemaNot(JsonSchema original, JsonSchema updated) {
+        if (original == null && updated == null) { traversalContext.skip(); return; }
         compareSchema(ctx, original, updated,
                 SUBSCHEMA_TYPE_CHANGED, SUBSCHEMA_TYPE_CHANGED,
                 NOT_TYPE_SCHEMA_COMPATIBLE_BOTH,
                 NOT_TYPE_SCHEMA_COMPATIBLE_BACKWARD_NOT_FORWARD,
                 NOT_TYPE_SCHEMA_COMPATIBLE_FORWARD_NOT_BACKWARD,
                 NOT_TYPE_SCHEMA_COMPATIBLE_NONE);
-        return false;
+        traversalContext.skip(); return;
     }
 
     // -----------------------------------------------------------------------
@@ -1056,39 +1056,39 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     // -----------------------------------------------------------------------
 
     @Override
-    public boolean diffFullSchemaIf(JsonSchema original, JsonSchema updated) {
-        if (original == null && updated == null) return false;
+    public void diffFullSchemaIf(JsonSchema original, JsonSchema updated) {
+        if (original == null && updated == null) { traversalContext.skip(); return; }
         compareSchema(ctx, original, updated,
                 CONDITIONAL_TYPE_IF_SCHEMA_ADDED, CONDITIONAL_TYPE_IF_SCHEMA_REMOVED,
                 CONDITIONAL_TYPE_IF_SCHEMA_COMPATIBLE_BOTH,
                 CONDITIONAL_TYPE_IF_SCHEMA_COMPATIBLE_BACKWARD_NOT_FORWARD,
                 CONDITIONAL_TYPE_IF_SCHEMA_COMPATIBLE_FORWARD_NOT_BACKWARD,
                 CONDITIONAL_TYPE_IF_SCHEMA_COMPATIBLE_NONE);
-        return false;
+        traversalContext.skip(); return;
     }
 
     @Override
-    public boolean diffFullSchemaThen(JsonSchema original, JsonSchema updated) {
-        if (original == null && updated == null) return false;
+    public void diffFullSchemaThen(JsonSchema original, JsonSchema updated) {
+        if (original == null && updated == null) { traversalContext.skip(); return; }
         compareSchema(ctx, original, updated,
                 CONDITIONAL_TYPE_THEN_SCHEMA_ADDED, CONDITIONAL_TYPE_THEN_SCHEMA_REMOVED,
                 CONDITIONAL_TYPE_THEN_SCHEMA_COMPATIBLE_BOTH,
                 CONDITIONAL_TYPE_THEN_SCHEMA_COMPATIBLE_BACKWARD_NOT_FORWARD,
                 CONDITIONAL_TYPE_THEN_SCHEMA_COMPATIBLE_FORWARD_NOT_BACKWARD,
                 CONDITIONAL_TYPE_THEN_SCHEMA_COMPATIBLE_NONE);
-        return false;
+        traversalContext.skip(); return;
     }
 
     @Override
-    public boolean diffFullSchemaElse(JsonSchema original, JsonSchema updated) {
-        if (original == null && updated == null) return false;
+    public void diffFullSchemaElse(JsonSchema original, JsonSchema updated) {
+        if (original == null && updated == null) { traversalContext.skip(); return; }
         compareSchema(ctx, original, updated,
                 CONDITIONAL_TYPE_ELSE_SCHEMA_ADDED, CONDITIONAL_TYPE_ELSE_SCHEMA_REMOVED,
                 CONDITIONAL_TYPE_ELSE_SCHEMA_COMPATIBLE_BOTH,
                 CONDITIONAL_TYPE_ELSE_SCHEMA_COMPATIBLE_BACKWARD_NOT_FORWARD,
                 CONDITIONAL_TYPE_ELSE_SCHEMA_COMPATIBLE_FORWARD_NOT_BACKWARD,
                 CONDITIONAL_TYPE_ELSE_SCHEMA_COMPATIBLE_NONE);
-        return false;
+        traversalContext.skip(); return;
     }
 
     // -----------------------------------------------------------------------
@@ -1166,7 +1166,7 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     // -----------------------------------------------------------------------
 
     @Override
-    public boolean diffFullSchemaType(
+    public void diffFullSchemaType(
             io.apitomy.datamodels.models.union.StringStringListUnion original,
             io.apitomy.datamodels.models.union.StringStringListUnion updated) {
         // Type change detection is handled in visitFullSchema.
@@ -1185,7 +1185,7 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
                         NUMBER_TYPE_INTEGER_REQUIRED_UNCHANGED);
             }
         }
-        return true;
+        return;
     }
 
     // -----------------------------------------------------------------------
@@ -1208,15 +1208,15 @@ public class CompoundSchemaDiffVisitor extends JCDiffVisitor<DefaultPairingKey> 
     // -----------------------------------------------------------------------
 
     @Override
-    public boolean diffFullSchemaContentSchema(JsonSchema original, JsonSchema updated) {
-        if (original == null && updated == null) return false;
+    public void diffFullSchemaContentSchema(JsonSchema original, JsonSchema updated) {
+        if (original == null && updated == null) { traversalContext.skip(); return; }
         if (original != null && updated != null) {
             var subCtx = ctx.sub("contentSchema");
             if (!isUnionSchemaCompatible(subCtx, original, updated, true)) {
                 subCtx.addDifference(SUBSCHEMA_TYPE_CHANGED, original, updated);
             }
         }
-        return false;
+        traversalContext.skip(); return;
     }
 
     // -----------------------------------------------------------------------

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffTraversersStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffTraversersStage.java
@@ -67,17 +67,21 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
         String providerFQN = getState().getConfig().getRootNamespace() + ".visitors.diff.PairingStrategyProvider";
         classSource.addImport(providerFQN);
 
+        // Import TraversalAction for context-based traversal control
+        String actionFQN = getState().getConfig().getRootNamespace() + ".visitors.TraversalAction";
+        classSource.addImport(actionFQN);
+
         // Constructors
         MethodSource<JavaClassSource> constructor = classSource.addMethod()
                 .setConstructor(true).setPublic();
         constructor.addParameter(visitorClassName + "<P>", "visitor");
-        constructor.setBody("super(visitor);");
+        constructor.setBody("super(visitor); visitor.setTraversalContext(this.originalContext);");
 
         MethodSource<JavaClassSource> constructor2 = classSource.addMethod()
                 .setConstructor(true).setPublic();
         constructor2.addParameter(visitorClassName, "visitor");
         constructor2.addParameter("PairingStrategyProvider<P>", "pairingProvider");
-        constructor2.setBody("super(visitor, pairingProvider);");
+        constructor2.setBody("super(visitor, pairingProvider); visitor.setTraversalContext(this.originalContext);");
 
         java.util.Set<String> createdMethods = new java.util.HashSet<>();
 
@@ -222,7 +226,13 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
 
         body.append("if (original == null && updated == null) return;");
         body.addContext("visitMethod", "visit" + entityName);
-        body.append("if (!visitor.${visitMethod}(original, updated)) return;");
+        body.addContext("afterVisitMethod", "afterVisit" + entityName);
+        body.append("this.originalContext.resetAction();");
+        body.append("visitor.${visitMethod}(original, updated);");
+        body.append("if (this.originalContext.consumeAction() == TraversalAction.SKIP) {");
+        body.append("    visitor.${afterVisitMethod}(original, updated);");
+        body.append("    return;");
+        body.append("}");
         body.append("if (original == null || updated == null) return;");
 
         for (PropertyModelWithOrigin propWithOrigin : allProperties) {
@@ -249,7 +259,9 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
                 jt.addImportsTo(classSource);
                 String afterDiffMethod = "afterDiff" + entityName + fieldSuffix;
                 body.addContext("afterDiffMethod", afterDiffMethod);
-                body.append("    if (visitor.${diffMethod}(original.${getter}(), updated.${getter}())) {");
+                body.append("    this.originalContext.resetAction();");
+                body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}());");
+                body.append("    if (this.originalContext.consumeAction() != TraversalAction.SKIP) {");
                 body.append("        if (original.${getter}() != null && updated.${getter}() != null) {");
                 body.append("            traverse(original.${getter}(), updated.${getter}());");
                 body.append("        }");
@@ -272,7 +284,9 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
                 body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}(), diff);");
                 body.append("    for (CollectionDiff.MatchedPair<P, " + valueTypeStr + "> pair : diff.getMatched()) {");
                 body.append("        pushListIndex(pair.getKey());");
-                body.append("        if (visitor.${visitMethod2}(pair.getOriginal(), pair.getUpdated())) {");
+                body.append("        this.originalContext.resetAction();");
+                body.append("        visitor.${visitMethod2}(pair.getOriginal(), pair.getUpdated());");
+                body.append("        if (this.originalContext.consumeAction() != TraversalAction.SKIP) {");
                 if (isEntityList(property)) {
                     body.append("            if (pair.getOriginal() != null && pair.getUpdated() != null) {");
                     body.append("                traverse(pair.getOriginal(), pair.getUpdated());");
@@ -306,7 +320,9 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
                 body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}(), diff);");
                 body.append("    for (CollectionDiff.MatchedPair<P, " + valueTypeStr + "> pair : diff.getMatched()) {");
                 body.append("        pushMapKey(pair.getKey());");
-                body.append("        if (visitor.${visitMethod2}(pair.getOriginal(), pair.getUpdated())) {");
+                body.append("        this.originalContext.resetAction();");
+                body.append("        visitor.${visitMethod2}(pair.getOriginal(), pair.getUpdated());");
+                body.append("        if (this.originalContext.consumeAction() != TraversalAction.SKIP) {");
                 if (isEntityMap(property)) {
                     body.append("            if (pair.getOriginal() != null && pair.getUpdated() != null) {");
                     body.append("                traverse(pair.getOriginal(), pair.getUpdated());");
@@ -329,7 +345,9 @@ public class CreateDiffTraversersStage extends AbstractJavaStage {
                 String afterDiffMethod = "afterDiff" + entityName + fieldSuffix;
                 body.addContext("traverseUnion", traverseUnion);
                 body.addContext("afterDiffMethod", afterDiffMethod);
-                body.append("    if (visitor.${diffMethod}(original.${getter}(), updated.${getter}())) {");
+                body.append("    this.originalContext.resetAction();");
+                body.append("    visitor.${diffMethod}(original.${getter}(), updated.${getter}());");
+                body.append("    if (this.originalContext.consumeAction() != TraversalAction.SKIP) {");
                 body.append("        this.${traverseUnion}(original.${getter}(), updated.${getter}());");
                 body.append("    }");
                 body.append("    visitor.${afterDiffMethod}(original.${getter}(), updated.${getter}());");

--- a/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffVisitorsStage.java
+++ b/generator/src/main/java/io/apitomy/umg/pipe/java/CreateDiffVisitorsStage.java
@@ -45,6 +45,21 @@ public class CreateDiffVisitorsStage extends AbstractJavaStage {
         classSource.addImport(pairingKeyFQN);
         classSource.addTypeVariable("P").setBounds("PairingKey");
 
+        // Add traversal context field for skip() support
+        String ctxFQN = getState().getConfig().getRootNamespace() + ".visitors.TraversalContext";
+        classSource.addImport(ctxFQN);
+        classSource.addField()
+                .setName("traversalContext")
+                .setType("TraversalContext")
+                .setProtected();
+
+        MethodSource<JavaClassSource> setter = classSource.addMethod()
+                .setName("setTraversalContext")
+                .setReturnTypeVoid()
+                .setPublic();
+        setter.addParameter("TraversalContext", "context");
+        setter.setBody("this.traversalContext = context;");
+
         JavaTypeFactory jtf = getJavaTypeFactory();
 
         specVer.getEntities().forEach(entity -> {
@@ -90,11 +105,11 @@ public class CreateDiffVisitorsStage extends AbstractJavaStage {
         String methodName = "visit" + entityModel.getName();
         MethodSource<JavaClassSource> method = classSource.addMethod()
                 .setName(methodName)
-                .setReturnType(boolean.class)
+                .setReturnTypeVoid()
                 .setPublic();
         method.addParameter(javaEntity.getName(), "original");
         method.addParameter(javaEntity.getName(), "updated");
-        method.setBody("return true;");
+        method.setBody("");
 
         String afterMethodName = "afterVisit" + entityModel.getName();
         MethodSource<JavaClassSource> afterMethod = classSource.addMethod()
@@ -162,11 +177,11 @@ public class CreateDiffVisitorsStage extends AbstractJavaStage {
         String methodName = "diff" + entityName + fieldSuffix;
         MethodSource<JavaClassSource> method = classSource.addMethod()
                 .setName(methodName)
-                .setReturnType(boolean.class)
+                .setReturnTypeVoid()
                 .setPublic();
         method.addParameter(jt.toJavaTypeString(), "original");
         method.addParameter(jt.toJavaTypeString(), "updated");
-        method.setBody("return true;");
+        method.setBody("");
 
         String afterMethodName = "afterDiff" + entityName + fieldSuffix;
         MethodSource<JavaClassSource> afterMethod = classSource.addMethod()
@@ -186,11 +201,11 @@ public class CreateDiffVisitorsStage extends AbstractJavaStage {
         String methodName = "diff" + entityName + fieldSuffix;
         MethodSource<JavaClassSource> method = classSource.addMethod()
                 .setName(methodName)
-                .setReturnType(boolean.class)
+                .setReturnTypeVoid()
                 .setPublic();
         method.addParameter(jt.toJavaTypeString(), "original");
         method.addParameter(jt.toJavaTypeString(), "updated");
-        method.setBody("return true;");
+        method.setBody("");
 
         String afterMethodName = "afterDiff" + entityName + fieldSuffix;
         MethodSource<JavaClassSource> afterMethod = classSource.addMethod()
@@ -227,11 +242,11 @@ public class CreateDiffVisitorsStage extends AbstractJavaStage {
         String visitMethodName = "visit" + entityName + fieldSuffix + "Item";
         MethodSource<JavaClassSource> visitMethod = classSource.addMethod()
                 .setName(visitMethodName)
-                .setReturnType(boolean.class)
+                .setReturnTypeVoid()
                 .setPublic();
         visitMethod.addParameter(valueJt.toJavaTypeString(), "original");
         visitMethod.addParameter(valueJt.toJavaTypeString(), "updated");
-        visitMethod.setBody("return true;");
+        visitMethod.setBody("");
 
         String afterVisitMethodName = "afterVisit" + entityName + fieldSuffix + "Item";
         MethodSource<JavaClassSource> afterVisitMethod = classSource.addMethod()
@@ -268,11 +283,11 @@ public class CreateDiffVisitorsStage extends AbstractJavaStage {
         String visitMethodName = "visit" + entityName + singularSuffix;
         MethodSource<JavaClassSource> visitMethod = classSource.addMethod()
                 .setName(visitMethodName)
-                .setReturnType(boolean.class)
+                .setReturnTypeVoid()
                 .setPublic();
         visitMethod.addParameter(valueJt.toJavaTypeString(), "original");
         visitMethod.addParameter(valueJt.toJavaTypeString(), "updated");
-        visitMethod.setBody("return true;");
+        visitMethod.setBody("");
 
         String afterVisitMethodName = "afterVisit" + entityName + singularSuffix;
         MethodSource<JavaClassSource> afterVisitMethod = classSource.addMethod()

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffTraverser.java
@@ -19,6 +19,7 @@ import io.test.synthetic.v1.Syn1Operation;
 import io.test.synthetic.v1.Syn1PathItem;
 import io.test.synthetic.v1.Syn1Paths;
 import io.test.synthetic.v1.Syn1Schema;
+import io.test.synthetic.visitors.TraversalAction;
 import io.test.synthetic.visitors.diff.AbstractDiffTraverser;
 import io.test.synthetic.visitors.diff.CollectionDiff;
 import io.test.synthetic.visitors.diff.PairingKey;
@@ -30,10 +31,12 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 
 	public Syn1DiffTraverser(Syn1DiffVisitor<P> visitor) {
 		super(visitor);
+		visitor.setTraversalContext(this.originalContext);
 	}
 
 	public Syn1DiffTraverser(Syn1DiffVisitor visitor, PairingStrategyProvider<P> pairingProvider) {
 		super(visitor, pairingProvider);
+		visitor.setTraversalContext(this.originalContext);
 	}
 
 	@Override
@@ -68,8 +71,12 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 	public void traverseDocument(Syn1Document original, Syn1Document updated) {
 		if (original == null && updated == null)
 			return;
-		if (!visitor.visitDocument(original, updated))
+		this.originalContext.resetAction();
+		visitor.visitDocument(original, updated);
+		if (this.originalContext.consumeAction() == TraversalAction.SKIP) {
+			visitor.afterVisitDocument(original, updated);
 			return;
+		}
 		if (original == null || updated == null)
 			return;
 		{
@@ -79,7 +86,9 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("info");
-			if (visitor.diffDocumentInfo(original.getInfo(), updated.getInfo())) {
+			this.originalContext.resetAction();
+			visitor.diffDocumentInfo(original.getInfo(), updated.getInfo());
+			if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 				if (original.getInfo() != null && updated.getInfo() != null) {
 					traverse(original.getInfo(), updated.getInfo());
 				}
@@ -93,7 +102,9 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffDocumentItems(original.getItems(), updated.getItems(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
 				pushListIndex(pair.getKey());
-				if (visitor.visitDocumentItemsItem(pair.getOriginal(), pair.getUpdated())) {
+				this.originalContext.resetAction();
+				visitor.visitDocumentItemsItem(pair.getOriginal(), pair.getUpdated());
+				if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 					if (pair.getOriginal() != null && pair.getUpdated() != null) {
 						traverse(pair.getOriginal(), pair.getUpdated());
 					}
@@ -115,7 +126,9 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("additionalSchema");
-			if (visitor.diffDocumentAdditionalSchema(original.getAdditionalSchema(), updated.getAdditionalSchema())) {
+			this.originalContext.resetAction();
+			visitor.diffDocumentAdditionalSchema(original.getAdditionalSchema(), updated.getAdditionalSchema());
+			if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 				this.traverseSchemaOrBoolean(original.getAdditionalSchema(), updated.getAdditionalSchema());
 			}
 			visitor.afterDiffDocumentAdditionalSchema(original.getAdditionalSchema(), updated.getAdditionalSchema());
@@ -127,8 +140,12 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 	public void traverseInfo(Syn1Info original, Syn1Info updated) {
 		if (original == null && updated == null)
 			return;
-		if (!visitor.visitInfo(original, updated))
+		this.originalContext.resetAction();
+		visitor.visitInfo(original, updated);
+		if (this.originalContext.consumeAction() == TraversalAction.SKIP) {
+			visitor.afterVisitInfo(original, updated);
 			return;
+		}
 		if (original == null || updated == null)
 			return;
 		{
@@ -138,7 +155,9 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("contact");
-			if (visitor.diffInfoContact(original.getContact(), updated.getContact())) {
+			this.originalContext.resetAction();
+			visitor.diffInfoContact(original.getContact(), updated.getContact());
+			if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 				if (original.getContact() != null && updated.getContact() != null) {
 					traverse(original.getContact(), updated.getContact());
 				}
@@ -157,8 +176,12 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 	public void traverseContact(Syn1Contact original, Syn1Contact updated) {
 		if (original == null && updated == null)
 			return;
-		if (!visitor.visitContact(original, updated))
+		this.originalContext.resetAction();
+		visitor.visitContact(original, updated);
+		if (this.originalContext.consumeAction() == TraversalAction.SKIP) {
+			visitor.afterVisitContact(original, updated);
 			return;
+		}
 		if (original == null || updated == null)
 			return;
 		{
@@ -182,8 +205,12 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 	public void traverseItem(Syn1Item original, Syn1Item updated) {
 		if (original == null && updated == null)
 			return;
-		if (!visitor.visitItem(original, updated))
+		this.originalContext.resetAction();
+		visitor.visitItem(original, updated);
+		if (this.originalContext.consumeAction() == TraversalAction.SKIP) {
+			visitor.afterVisitItem(original, updated);
 			return;
+		}
 		if (original == null || updated == null)
 			return;
 		{
@@ -223,7 +250,9 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("schema");
-			if (visitor.diffItemSchema(original.getSchema(), updated.getSchema())) {
+			this.originalContext.resetAction();
+			visitor.diffItemSchema(original.getSchema(), updated.getSchema());
+			if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 				if (original.getSchema() != null && updated.getSchema() != null) {
 					traverse(original.getSchema(), updated.getSchema());
 				}
@@ -238,7 +267,9 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("defaultValue");
-			if (visitor.diffItemDefaultValue(original.getDefaultValue(), updated.getDefaultValue())) {
+			this.originalContext.resetAction();
+			visitor.diffItemDefaultValue(original.getDefaultValue(), updated.getDefaultValue());
+			if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 				this.traverseBooleanSchemaUnion(original.getDefaultValue(), updated.getDefaultValue());
 			}
 			visitor.afterDiffItemDefaultValue(original.getDefaultValue(), updated.getDefaultValue());
@@ -255,8 +286,12 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 	public void traverseSchema(Syn1Schema original, Syn1Schema updated) {
 		if (original == null && updated == null)
 			return;
-		if (!visitor.visitSchema(original, updated))
+		this.originalContext.resetAction();
+		visitor.visitSchema(original, updated);
+		if (this.originalContext.consumeAction() == TraversalAction.SKIP) {
+			visitor.afterVisitSchema(original, updated);
 			return;
+		}
 		if (original == null || updated == null)
 			return;
 		{
@@ -271,7 +306,9 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("items");
-			if (visitor.diffSchemaItems(original.getItems(), updated.getItems())) {
+			this.originalContext.resetAction();
+			visitor.diffSchemaItems(original.getItems(), updated.getItems());
+			if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 				this.traverseBooleanSchemaSchemaListUnion(original.getItems(), updated.getItems());
 			}
 			visitor.afterDiffSchemaItems(original.getItems(), updated.getItems());
@@ -284,7 +321,9 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaProperties(original.getProperties(), updated.getProperties(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
 				pushMapKey(pair.getKey());
-				if (visitor.visitSchemaProperty(pair.getOriginal(), pair.getUpdated())) {
+				this.originalContext.resetAction();
+				visitor.visitSchemaProperty(pair.getOriginal(), pair.getUpdated());
+				if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 					this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				}
 				visitor.afterVisitSchemaProperty(pair.getOriginal(), pair.getUpdated());
@@ -299,7 +338,9 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaAllOf(original.getAllOf(), updated.getAllOf(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
 				pushListIndex(pair.getKey());
-				if (visitor.visitSchemaAllOfItem(pair.getOriginal(), pair.getUpdated())) {
+				this.originalContext.resetAction();
+				visitor.visitSchemaAllOfItem(pair.getOriginal(), pair.getUpdated());
+				if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 					this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				}
 				visitor.afterVisitSchemaAllOfItem(pair.getOriginal(), pair.getUpdated());
@@ -314,7 +355,9 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaDefinitions(original.getDefinitions(), updated.getDefinitions(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
 				pushMapKey(pair.getKey());
-				if (visitor.visitSchemaDefinition(pair.getOriginal(), pair.getUpdated())) {
+				this.originalContext.resetAction();
+				visitor.visitSchemaDefinition(pair.getOriginal(), pair.getUpdated());
+				if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 					this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				}
 				visitor.afterVisitSchemaDefinition(pair.getOriginal(), pair.getUpdated());
@@ -329,7 +372,9 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaNestedSchemas(original.getNestedSchemas(), updated.getNestedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
 				pushMapKey(pair.getKey());
-				if (visitor.visitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated())) {
+				this.originalContext.resetAction();
+				visitor.visitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated());
+				if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 					this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
 				}
 				visitor.afterVisitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated());
@@ -344,7 +389,9 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaComposedSchemas(original.getComposedSchemas(), updated.getComposedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
 				pushListIndex(pair.getKey());
-				if (visitor.visitSchemaComposedSchemasItem(pair.getOriginal(), pair.getUpdated())) {
+				this.originalContext.resetAction();
+				visitor.visitSchemaComposedSchemasItem(pair.getOriginal(), pair.getUpdated());
+				if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 					this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
 				}
 				visitor.afterVisitSchemaComposedSchemasItem(pair.getOriginal(), pair.getUpdated());
@@ -373,8 +420,12 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 	public void traversePaths(Syn1Paths original, Syn1Paths updated) {
 		if (original == null && updated == null)
 			return;
-		if (!visitor.visitPaths(original, updated))
+		this.originalContext.resetAction();
+		visitor.visitPaths(original, updated);
+		if (this.originalContext.consumeAction() == TraversalAction.SKIP) {
+			visitor.afterVisitPaths(original, updated);
 			return;
+		}
 		if (original == null || updated == null)
 			return;
 		visitor.afterVisitPaths(original, updated);
@@ -383,8 +434,12 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 	public void traversePathItem(Syn1PathItem original, Syn1PathItem updated) {
 		if (original == null && updated == null)
 			return;
-		if (!visitor.visitPathItem(original, updated))
+		this.originalContext.resetAction();
+		visitor.visitPathItem(original, updated);
+		if (this.originalContext.consumeAction() == TraversalAction.SKIP) {
+			visitor.afterVisitPathItem(original, updated);
 			return;
+		}
 		if (original == null || updated == null)
 			return;
 		{
@@ -399,7 +454,9 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("get");
-			if (visitor.diffPathItemGet(original.getGet(), updated.getGet())) {
+			this.originalContext.resetAction();
+			visitor.diffPathItemGet(original.getGet(), updated.getGet());
+			if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 				if (original.getGet() != null && updated.getGet() != null) {
 					traverse(original.getGet(), updated.getGet());
 				}
@@ -409,7 +466,9 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("put");
-			if (visitor.diffPathItemPut(original.getPut(), updated.getPut())) {
+			this.originalContext.resetAction();
+			visitor.diffPathItemPut(original.getPut(), updated.getPut());
+			if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 				if (original.getPut() != null && updated.getPut() != null) {
 					traverse(original.getPut(), updated.getPut());
 				}
@@ -419,7 +478,9 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("post");
-			if (visitor.diffPathItemPost(original.getPost(), updated.getPost())) {
+			this.originalContext.resetAction();
+			visitor.diffPathItemPost(original.getPost(), updated.getPost());
+			if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 				if (original.getPost() != null && updated.getPost() != null) {
 					traverse(original.getPost(), updated.getPost());
 				}
@@ -433,8 +494,12 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 	public void traverseOperation(Syn1Operation original, Syn1Operation updated) {
 		if (original == null && updated == null)
 			return;
-		if (!visitor.visitOperation(original, updated))
+		this.originalContext.resetAction();
+		visitor.visitOperation(original, updated);
+		if (this.originalContext.consumeAction() == TraversalAction.SKIP) {
+			visitor.afterVisitOperation(original, updated);
 			return;
+		}
 		if (original == null || updated == null)
 			return;
 		{
@@ -459,7 +524,9 @@ public class Syn1DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffOperationParameters(original.getParameters(), updated.getParameters(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
 				pushListIndex(pair.getKey());
-				if (visitor.visitOperationParametersItem(pair.getOriginal(), pair.getUpdated())) {
+				this.originalContext.resetAction();
+				visitor.visitOperationParametersItem(pair.getOriginal(), pair.getUpdated());
+				if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 					if (pair.getOriginal() != null && pair.getUpdated() != null) {
 						traverse(pair.getOriginal(), pair.getUpdated());
 					}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffVisitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v1/visitors/Syn1DiffVisitor.java
@@ -18,6 +18,7 @@ import io.test.synthetic.v1.Syn1Operation;
 import io.test.synthetic.v1.Syn1PathItem;
 import io.test.synthetic.v1.Syn1Paths;
 import io.test.synthetic.v1.Syn1Schema;
+import io.test.synthetic.visitors.TraversalContext;
 import io.test.synthetic.visitors.diff.CollectionDiff;
 import io.test.synthetic.visitors.diff.PairingKey;
 import java.util.List;
@@ -25,8 +26,13 @@ import java.util.Map;
 
 public abstract class Syn1DiffVisitor<P extends PairingKey> {
 
-	public boolean visitDocument(Syn1Document original, Syn1Document updated) {
-		return true;
+	protected TraversalContext traversalContext;
+
+	public void setTraversalContext(TraversalContext context) {
+		this.traversalContext = context;
+	}
+
+	public void visitDocument(Syn1Document original, Syn1Document updated) {
 	}
 
 	public void afterVisitDocument(Syn1Document original, Syn1Document updated) {
@@ -35,8 +41,7 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 	public void diffDocumentVersion(String original, String updated) {
 	}
 
-	public boolean diffDocumentInfo(SynInfo original, SynInfo updated) {
-		return true;
+	public void diffDocumentInfo(SynInfo original, SynInfo updated) {
 	}
 
 	public void afterDiffDocumentInfo(SynInfo original, SynInfo updated) {
@@ -45,8 +50,7 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 	public void diffDocumentItems(List<SynItem> original, List<SynItem> updated, CollectionDiff<P, SynItem> diff) {
 	}
 
-	public boolean visitDocumentItemsItem(SynItem original, SynItem updated) {
-		return true;
+	public void visitDocumentItemsItem(SynItem original, SynItem updated) {
 	}
 
 	public void afterVisitDocumentItemsItem(SynItem original, SynItem updated) {
@@ -58,15 +62,13 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 	public void diffDocumentMetadata(Map<String, String> original, Map<String, String> updated) {
 	}
 
-	public boolean diffDocumentAdditionalSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
-		return true;
+	public void diffDocumentAdditionalSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
 	}
 
 	public void afterDiffDocumentAdditionalSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
 	}
 
-	public boolean visitInfo(Syn1Info original, Syn1Info updated) {
-		return true;
+	public void visitInfo(Syn1Info original, Syn1Info updated) {
 	}
 
 	public void afterVisitInfo(Syn1Info original, Syn1Info updated) {
@@ -75,8 +77,7 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 	public void diffInfoName(String original, String updated) {
 	}
 
-	public boolean diffInfoContact(SynContact original, SynContact updated) {
-		return true;
+	public void diffInfoContact(SynContact original, SynContact updated) {
 	}
 
 	public void afterDiffInfoContact(SynContact original, SynContact updated) {
@@ -85,8 +86,7 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 	public void diffInfoVersion(String original, String updated) {
 	}
 
-	public boolean visitContact(Syn1Contact original, Syn1Contact updated) {
-		return true;
+	public void visitContact(Syn1Contact original, Syn1Contact updated) {
 	}
 
 	public void afterVisitContact(Syn1Contact original, Syn1Contact updated) {
@@ -101,8 +101,7 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 	public void diffContactUrl(String original, String updated) {
 	}
 
-	public boolean visitItem(Syn1Item original, Syn1Item updated) {
-		return true;
+	public void visitItem(Syn1Item original, Syn1Item updated) {
 	}
 
 	public void afterVisitItem(Syn1Item original, Syn1Item updated) {
@@ -129,8 +128,7 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 	public void diffItemRaw(ObjectNode original, ObjectNode updated) {
 	}
 
-	public boolean diffItemSchema(SynSchema original, SynSchema updated) {
-		return true;
+	public void diffItemSchema(SynSchema original, SynSchema updated) {
 	}
 
 	public void afterDiffItemSchema(SynSchema original, SynSchema updated) {
@@ -139,8 +137,7 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 	public void diffItemExamples(List<JsonNode> original, List<JsonNode> updated) {
 	}
 
-	public boolean diffItemDefaultValue(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
-		return true;
+	public void diffItemDefaultValue(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
 	}
 
 	public void afterDiffItemDefaultValue(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
@@ -149,8 +146,7 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 	public void diffItemTitle(String original, String updated) {
 	}
 
-	public boolean visitSchema(Syn1Schema original, Syn1Schema updated) {
-		return true;
+	public void visitSchema(Syn1Schema original, Syn1Schema updated) {
 	}
 
 	public void afterVisitSchema(Syn1Schema original, Syn1Schema updated) {
@@ -162,8 +158,7 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 	public void diffSchemaType(String original, String updated) {
 	}
 
-	public boolean diffSchemaItems(BooleanSchemaSchemaListUnion original, BooleanSchemaSchemaListUnion updated) {
-		return true;
+	public void diffSchemaItems(BooleanSchemaSchemaListUnion original, BooleanSchemaSchemaListUnion updated) {
 	}
 
 	public void afterDiffSchemaItems(BooleanSchemaSchemaListUnion original, BooleanSchemaSchemaListUnion updated) {
@@ -173,8 +168,7 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 			CollectionDiff<P, BooleanSchemaUnion> diff) {
 	}
 
-	public boolean visitSchemaProperty(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
-		return true;
+	public void visitSchemaProperty(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
 	}
 
 	public void afterVisitSchemaProperty(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
@@ -184,8 +178,7 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 			CollectionDiff<P, BooleanSchemaUnion> diff) {
 	}
 
-	public boolean visitSchemaAllOfItem(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
-		return true;
+	public void visitSchemaAllOfItem(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
 	}
 
 	public void afterVisitSchemaAllOfItem(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
@@ -195,8 +188,7 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 			CollectionDiff<P, BooleanSchemaUnion> diff) {
 	}
 
-	public boolean visitSchemaDefinition(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
-		return true;
+	public void visitSchemaDefinition(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
 	}
 
 	public void afterVisitSchemaDefinition(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
@@ -206,8 +198,7 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 			CollectionDiff<P, SchemaOrBoolean> diff) {
 	}
 
-	public boolean visitSchemaNestedSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
-		return true;
+	public void visitSchemaNestedSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
 	}
 
 	public void afterVisitSchemaNestedSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
@@ -217,8 +208,7 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 			CollectionDiff<P, SchemaOrBoolean> diff) {
 	}
 
-	public boolean visitSchemaComposedSchemasItem(SchemaOrBoolean original, SchemaOrBoolean updated) {
-		return true;
+	public void visitSchemaComposedSchemasItem(SchemaOrBoolean original, SchemaOrBoolean updated) {
 	}
 
 	public void afterVisitSchemaComposedSchemasItem(SchemaOrBoolean original, SchemaOrBoolean updated) {
@@ -233,15 +223,13 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 	public void diffSchemaEnum(List<JsonNode> original, List<JsonNode> updated) {
 	}
 
-	public boolean visitPaths(Syn1Paths original, Syn1Paths updated) {
-		return true;
+	public void visitPaths(Syn1Paths original, Syn1Paths updated) {
 	}
 
 	public void afterVisitPaths(Syn1Paths original, Syn1Paths updated) {
 	}
 
-	public boolean visitPathItem(Syn1PathItem original, Syn1PathItem updated) {
-		return true;
+	public void visitPathItem(Syn1PathItem original, Syn1PathItem updated) {
 	}
 
 	public void afterVisitPathItem(Syn1PathItem original, Syn1PathItem updated) {
@@ -253,29 +241,25 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 	public void diffPathItemSummary(String original, String updated) {
 	}
 
-	public boolean diffPathItemGet(SynOperation original, SynOperation updated) {
-		return true;
+	public void diffPathItemGet(SynOperation original, SynOperation updated) {
 	}
 
 	public void afterDiffPathItemGet(SynOperation original, SynOperation updated) {
 	}
 
-	public boolean diffPathItemPut(SynOperation original, SynOperation updated) {
-		return true;
+	public void diffPathItemPut(SynOperation original, SynOperation updated) {
 	}
 
 	public void afterDiffPathItemPut(SynOperation original, SynOperation updated) {
 	}
 
-	public boolean diffPathItemPost(SynOperation original, SynOperation updated) {
-		return true;
+	public void diffPathItemPost(SynOperation original, SynOperation updated) {
 	}
 
 	public void afterDiffPathItemPost(SynOperation original, SynOperation updated) {
 	}
 
-	public boolean visitOperation(Syn1Operation original, Syn1Operation updated) {
-		return true;
+	public void visitOperation(Syn1Operation original, Syn1Operation updated) {
 	}
 
 	public void afterVisitOperation(Syn1Operation original, Syn1Operation updated) {
@@ -294,8 +278,7 @@ public abstract class Syn1DiffVisitor<P extends PairingKey> {
 			CollectionDiff<P, SynItem> diff) {
 	}
 
-	public boolean visitOperationParametersItem(SynItem original, SynItem updated) {
-		return true;
+	public void visitOperationParametersItem(SynItem original, SynItem updated) {
 	}
 
 	public void afterVisitOperationParametersItem(SynItem original, SynItem updated) {

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffTraverser.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffTraverser.java
@@ -19,6 +19,7 @@ import io.test.synthetic.v2.Syn2Operation;
 import io.test.synthetic.v2.Syn2PathItem;
 import io.test.synthetic.v2.Syn2Paths;
 import io.test.synthetic.v2.Syn2Schema;
+import io.test.synthetic.visitors.TraversalAction;
 import io.test.synthetic.visitors.diff.AbstractDiffTraverser;
 import io.test.synthetic.visitors.diff.CollectionDiff;
 import io.test.synthetic.visitors.diff.PairingKey;
@@ -30,10 +31,12 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 
 	public Syn2DiffTraverser(Syn2DiffVisitor<P> visitor) {
 		super(visitor);
+		visitor.setTraversalContext(this.originalContext);
 	}
 
 	public Syn2DiffTraverser(Syn2DiffVisitor visitor, PairingStrategyProvider<P> pairingProvider) {
 		super(visitor, pairingProvider);
+		visitor.setTraversalContext(this.originalContext);
 	}
 
 	@Override
@@ -68,8 +71,12 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 	public void traverseDocument(Syn2Document original, Syn2Document updated) {
 		if (original == null && updated == null)
 			return;
-		if (!visitor.visitDocument(original, updated))
+		this.originalContext.resetAction();
+		visitor.visitDocument(original, updated);
+		if (this.originalContext.consumeAction() == TraversalAction.SKIP) {
+			visitor.afterVisitDocument(original, updated);
 			return;
+		}
 		if (original == null || updated == null)
 			return;
 		{
@@ -79,7 +86,9 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("info");
-			if (visitor.diffDocumentInfo(original.getInfo(), updated.getInfo())) {
+			this.originalContext.resetAction();
+			visitor.diffDocumentInfo(original.getInfo(), updated.getInfo());
+			if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 				if (original.getInfo() != null && updated.getInfo() != null) {
 					traverse(original.getInfo(), updated.getInfo());
 				}
@@ -93,7 +102,9 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffDocumentItems(original.getItems(), updated.getItems(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
 				pushListIndex(pair.getKey());
-				if (visitor.visitDocumentItemsItem(pair.getOriginal(), pair.getUpdated())) {
+				this.originalContext.resetAction();
+				visitor.visitDocumentItemsItem(pair.getOriginal(), pair.getUpdated());
+				if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 					if (pair.getOriginal() != null && pair.getUpdated() != null) {
 						traverse(pair.getOriginal(), pair.getUpdated());
 					}
@@ -120,7 +131,9 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffDocumentWebhooks(original.getWebhooks(), updated.getWebhooks(), diff);
 			for (CollectionDiff.MatchedPair<P, Syn2PathItem> pair : diff.getMatched()) {
 				pushMapKey(pair.getKey());
-				if (visitor.visitDocumentWebhook(pair.getOriginal(), pair.getUpdated())) {
+				this.originalContext.resetAction();
+				visitor.visitDocumentWebhook(pair.getOriginal(), pair.getUpdated());
+				if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 					if (pair.getOriginal() != null && pair.getUpdated() != null) {
 						traverse(pair.getOriginal(), pair.getUpdated());
 					}
@@ -132,7 +145,9 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("additionalSchema");
-			if (visitor.diffDocumentAdditionalSchema(original.getAdditionalSchema(), updated.getAdditionalSchema())) {
+			this.originalContext.resetAction();
+			visitor.diffDocumentAdditionalSchema(original.getAdditionalSchema(), updated.getAdditionalSchema());
+			if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 				this.traverseSchemaOrBoolean(original.getAdditionalSchema(), updated.getAdditionalSchema());
 			}
 			visitor.afterDiffDocumentAdditionalSchema(original.getAdditionalSchema(), updated.getAdditionalSchema());
@@ -144,8 +159,12 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 	public void traverseInfo(Syn2Info original, Syn2Info updated) {
 		if (original == null && updated == null)
 			return;
-		if (!visitor.visitInfo(original, updated))
+		this.originalContext.resetAction();
+		visitor.visitInfo(original, updated);
+		if (this.originalContext.consumeAction() == TraversalAction.SKIP) {
+			visitor.afterVisitInfo(original, updated);
 			return;
+		}
 		if (original == null || updated == null)
 			return;
 		{
@@ -155,7 +174,9 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("contact");
-			if (visitor.diffInfoContact(original.getContact(), updated.getContact())) {
+			this.originalContext.resetAction();
+			visitor.diffInfoContact(original.getContact(), updated.getContact());
+			if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 				if (original.getContact() != null && updated.getContact() != null) {
 					traverse(original.getContact(), updated.getContact());
 				}
@@ -179,8 +200,12 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 	public void traverseContact(Syn2Contact original, Syn2Contact updated) {
 		if (original == null && updated == null)
 			return;
-		if (!visitor.visitContact(original, updated))
+		this.originalContext.resetAction();
+		visitor.visitContact(original, updated);
+		if (this.originalContext.consumeAction() == TraversalAction.SKIP) {
+			visitor.afterVisitContact(original, updated);
 			return;
+		}
 		if (original == null || updated == null)
 			return;
 		{
@@ -204,8 +229,12 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 	public void traverseItem(Syn2Item original, Syn2Item updated) {
 		if (original == null && updated == null)
 			return;
-		if (!visitor.visitItem(original, updated))
+		this.originalContext.resetAction();
+		visitor.visitItem(original, updated);
+		if (this.originalContext.consumeAction() == TraversalAction.SKIP) {
+			visitor.afterVisitItem(original, updated);
 			return;
+		}
 		if (original == null || updated == null)
 			return;
 		{
@@ -245,7 +274,9 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("schema");
-			if (visitor.diffItemSchema(original.getSchema(), updated.getSchema())) {
+			this.originalContext.resetAction();
+			visitor.diffItemSchema(original.getSchema(), updated.getSchema());
+			if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 				if (original.getSchema() != null && updated.getSchema() != null) {
 					traverse(original.getSchema(), updated.getSchema());
 				}
@@ -260,7 +291,9 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("defaultValue");
-			if (visitor.diffItemDefaultValue(original.getDefaultValue(), updated.getDefaultValue())) {
+			this.originalContext.resetAction();
+			visitor.diffItemDefaultValue(original.getDefaultValue(), updated.getDefaultValue());
+			if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 				this.traverseBooleanSchemaUnion(original.getDefaultValue(), updated.getDefaultValue());
 			}
 			visitor.afterDiffItemDefaultValue(original.getDefaultValue(), updated.getDefaultValue());
@@ -282,8 +315,12 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 	public void traverseSchema(Syn2Schema original, Syn2Schema updated) {
 		if (original == null && updated == null)
 			return;
-		if (!visitor.visitSchema(original, updated))
+		this.originalContext.resetAction();
+		visitor.visitSchema(original, updated);
+		if (this.originalContext.consumeAction() == TraversalAction.SKIP) {
+			visitor.afterVisitSchema(original, updated);
 			return;
+		}
 		if (original == null || updated == null)
 			return;
 		{
@@ -298,7 +335,9 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("items");
-			if (visitor.diffSchemaItems(original.getItems(), updated.getItems())) {
+			this.originalContext.resetAction();
+			visitor.diffSchemaItems(original.getItems(), updated.getItems());
+			if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 				this.traverseBooleanSchemaSchemaListUnion(original.getItems(), updated.getItems());
 			}
 			visitor.afterDiffSchemaItems(original.getItems(), updated.getItems());
@@ -311,7 +350,9 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaProperties(original.getProperties(), updated.getProperties(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
 				pushMapKey(pair.getKey());
-				if (visitor.visitSchemaProperty(pair.getOriginal(), pair.getUpdated())) {
+				this.originalContext.resetAction();
+				visitor.visitSchemaProperty(pair.getOriginal(), pair.getUpdated());
+				if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 					this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				}
 				visitor.afterVisitSchemaProperty(pair.getOriginal(), pair.getUpdated());
@@ -326,7 +367,9 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaAllOf(original.getAllOf(), updated.getAllOf(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
 				pushListIndex(pair.getKey());
-				if (visitor.visitSchemaAllOfItem(pair.getOriginal(), pair.getUpdated())) {
+				this.originalContext.resetAction();
+				visitor.visitSchemaAllOfItem(pair.getOriginal(), pair.getUpdated());
+				if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 					this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				}
 				visitor.afterVisitSchemaAllOfItem(pair.getOriginal(), pair.getUpdated());
@@ -341,7 +384,9 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaDefinitions(original.getDefinitions(), updated.getDefinitions(), diff);
 			for (CollectionDiff.MatchedPair<P, BooleanSchemaUnion> pair : diff.getMatched()) {
 				pushMapKey(pair.getKey());
-				if (visitor.visitSchemaDefinition(pair.getOriginal(), pair.getUpdated())) {
+				this.originalContext.resetAction();
+				visitor.visitSchemaDefinition(pair.getOriginal(), pair.getUpdated());
+				if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 					this.traverseBooleanSchemaUnion(pair.getOriginal(), pair.getUpdated());
 				}
 				visitor.afterVisitSchemaDefinition(pair.getOriginal(), pair.getUpdated());
@@ -356,7 +401,9 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaNestedSchemas(original.getNestedSchemas(), updated.getNestedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
 				pushMapKey(pair.getKey());
-				if (visitor.visitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated())) {
+				this.originalContext.resetAction();
+				visitor.visitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated());
+				if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 					this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
 				}
 				visitor.afterVisitSchemaNestedSchema(pair.getOriginal(), pair.getUpdated());
@@ -371,7 +418,9 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffSchemaComposedSchemas(original.getComposedSchemas(), updated.getComposedSchemas(), diff);
 			for (CollectionDiff.MatchedPair<P, SchemaOrBoolean> pair : diff.getMatched()) {
 				pushListIndex(pair.getKey());
-				if (visitor.visitSchemaComposedSchemasItem(pair.getOriginal(), pair.getUpdated())) {
+				this.originalContext.resetAction();
+				visitor.visitSchemaComposedSchemasItem(pair.getOriginal(), pair.getUpdated());
+				if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 					this.traverseSchemaOrBoolean(pair.getOriginal(), pair.getUpdated());
 				}
 				visitor.afterVisitSchemaComposedSchemasItem(pair.getOriginal(), pair.getUpdated());
@@ -400,8 +449,12 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 	public void traversePaths(Syn2Paths original, Syn2Paths updated) {
 		if (original == null && updated == null)
 			return;
-		if (!visitor.visitPaths(original, updated))
+		this.originalContext.resetAction();
+		visitor.visitPaths(original, updated);
+		if (this.originalContext.consumeAction() == TraversalAction.SKIP) {
+			visitor.afterVisitPaths(original, updated);
 			return;
+		}
 		if (original == null || updated == null)
 			return;
 		visitor.afterVisitPaths(original, updated);
@@ -410,8 +463,12 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 	public void traversePathItem(Syn2PathItem original, Syn2PathItem updated) {
 		if (original == null && updated == null)
 			return;
-		if (!visitor.visitPathItem(original, updated))
+		this.originalContext.resetAction();
+		visitor.visitPathItem(original, updated);
+		if (this.originalContext.consumeAction() == TraversalAction.SKIP) {
+			visitor.afterVisitPathItem(original, updated);
 			return;
+		}
 		if (original == null || updated == null)
 			return;
 		{
@@ -426,7 +483,9 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("get");
-			if (visitor.diffPathItemGet(original.getGet(), updated.getGet())) {
+			this.originalContext.resetAction();
+			visitor.diffPathItemGet(original.getGet(), updated.getGet());
+			if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 				if (original.getGet() != null && updated.getGet() != null) {
 					traverse(original.getGet(), updated.getGet());
 				}
@@ -436,7 +495,9 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("put");
-			if (visitor.diffPathItemPut(original.getPut(), updated.getPut())) {
+			this.originalContext.resetAction();
+			visitor.diffPathItemPut(original.getPut(), updated.getPut());
+			if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 				if (original.getPut() != null && updated.getPut() != null) {
 					traverse(original.getPut(), updated.getPut());
 				}
@@ -446,7 +507,9 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("post");
-			if (visitor.diffPathItemPost(original.getPost(), updated.getPost())) {
+			this.originalContext.resetAction();
+			visitor.diffPathItemPost(original.getPost(), updated.getPost());
+			if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 				if (original.getPost() != null && updated.getPost() != null) {
 					traverse(original.getPost(), updated.getPost());
 				}
@@ -456,7 +519,9 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 		}
 		{
 			pushProperty("delete");
-			if (visitor.diffPathItemDelete(original.getDelete(), updated.getDelete())) {
+			this.originalContext.resetAction();
+			visitor.diffPathItemDelete(original.getDelete(), updated.getDelete());
+			if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 				if (original.getDelete() != null && updated.getDelete() != null) {
 					traverse(original.getDelete(), updated.getDelete());
 				}
@@ -470,8 +535,12 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 	public void traverseOperation(Syn2Operation original, Syn2Operation updated) {
 		if (original == null && updated == null)
 			return;
-		if (!visitor.visitOperation(original, updated))
+		this.originalContext.resetAction();
+		visitor.visitOperation(original, updated);
+		if (this.originalContext.consumeAction() == TraversalAction.SKIP) {
+			visitor.afterVisitOperation(original, updated);
 			return;
+		}
 		if (original == null || updated == null)
 			return;
 		{
@@ -496,7 +565,9 @@ public class Syn2DiffTraverser<P extends PairingKey> extends AbstractDiffTravers
 			visitor.diffOperationParameters(original.getParameters(), updated.getParameters(), diff);
 			for (CollectionDiff.MatchedPair<P, SynItem> pair : diff.getMatched()) {
 				pushListIndex(pair.getKey());
-				if (visitor.visitOperationParametersItem(pair.getOriginal(), pair.getUpdated())) {
+				this.originalContext.resetAction();
+				visitor.visitOperationParametersItem(pair.getOriginal(), pair.getUpdated());
+				if (this.originalContext.consumeAction() != TraversalAction.SKIP) {
 					if (pair.getOriginal() != null && pair.getUpdated() != null) {
 						traverse(pair.getOriginal(), pair.getUpdated());
 					}

--- a/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffVisitor.java
+++ b/generator/src/test/resources/io/apitomy/umg/synthetic/expected/io/test/synthetic/v2/visitors/Syn2DiffVisitor.java
@@ -18,6 +18,7 @@ import io.test.synthetic.v2.Syn2Operation;
 import io.test.synthetic.v2.Syn2PathItem;
 import io.test.synthetic.v2.Syn2Paths;
 import io.test.synthetic.v2.Syn2Schema;
+import io.test.synthetic.visitors.TraversalContext;
 import io.test.synthetic.visitors.diff.CollectionDiff;
 import io.test.synthetic.visitors.diff.PairingKey;
 import java.util.List;
@@ -25,8 +26,13 @@ import java.util.Map;
 
 public abstract class Syn2DiffVisitor<P extends PairingKey> {
 
-	public boolean visitDocument(Syn2Document original, Syn2Document updated) {
-		return true;
+	protected TraversalContext traversalContext;
+
+	public void setTraversalContext(TraversalContext context) {
+		this.traversalContext = context;
+	}
+
+	public void visitDocument(Syn2Document original, Syn2Document updated) {
 	}
 
 	public void afterVisitDocument(Syn2Document original, Syn2Document updated) {
@@ -35,8 +41,7 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 	public void diffDocumentVersion(String original, String updated) {
 	}
 
-	public boolean diffDocumentInfo(SynInfo original, SynInfo updated) {
-		return true;
+	public void diffDocumentInfo(SynInfo original, SynInfo updated) {
 	}
 
 	public void afterDiffDocumentInfo(SynInfo original, SynInfo updated) {
@@ -45,8 +50,7 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 	public void diffDocumentItems(List<SynItem> original, List<SynItem> updated, CollectionDiff<P, SynItem> diff) {
 	}
 
-	public boolean visitDocumentItemsItem(SynItem original, SynItem updated) {
-		return true;
+	public void visitDocumentItemsItem(SynItem original, SynItem updated) {
 	}
 
 	public void afterVisitDocumentItemsItem(SynItem original, SynItem updated) {
@@ -62,22 +66,19 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 			CollectionDiff<P, Syn2PathItem> diff) {
 	}
 
-	public boolean visitDocumentWebhook(Syn2PathItem original, Syn2PathItem updated) {
-		return true;
+	public void visitDocumentWebhook(Syn2PathItem original, Syn2PathItem updated) {
 	}
 
 	public void afterVisitDocumentWebhook(Syn2PathItem original, Syn2PathItem updated) {
 	}
 
-	public boolean diffDocumentAdditionalSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
-		return true;
+	public void diffDocumentAdditionalSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
 	}
 
 	public void afterDiffDocumentAdditionalSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
 	}
 
-	public boolean visitInfo(Syn2Info original, Syn2Info updated) {
-		return true;
+	public void visitInfo(Syn2Info original, Syn2Info updated) {
 	}
 
 	public void afterVisitInfo(Syn2Info original, Syn2Info updated) {
@@ -86,8 +87,7 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 	public void diffInfoName(String original, String updated) {
 	}
 
-	public boolean diffInfoContact(SynContact original, SynContact updated) {
-		return true;
+	public void diffInfoContact(SynContact original, SynContact updated) {
 	}
 
 	public void afterDiffInfoContact(SynContact original, SynContact updated) {
@@ -99,8 +99,7 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 	public void diffInfoLicense(String original, String updated) {
 	}
 
-	public boolean visitContact(Syn2Contact original, Syn2Contact updated) {
-		return true;
+	public void visitContact(Syn2Contact original, Syn2Contact updated) {
 	}
 
 	public void afterVisitContact(Syn2Contact original, Syn2Contact updated) {
@@ -115,8 +114,7 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 	public void diffContactUrl(String original, String updated) {
 	}
 
-	public boolean visitItem(Syn2Item original, Syn2Item updated) {
-		return true;
+	public void visitItem(Syn2Item original, Syn2Item updated) {
 	}
 
 	public void afterVisitItem(Syn2Item original, Syn2Item updated) {
@@ -143,8 +141,7 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 	public void diffItemRaw(ObjectNode original, ObjectNode updated) {
 	}
 
-	public boolean diffItemSchema(SynSchema original, SynSchema updated) {
-		return true;
+	public void diffItemSchema(SynSchema original, SynSchema updated) {
 	}
 
 	public void afterDiffItemSchema(SynSchema original, SynSchema updated) {
@@ -153,8 +150,7 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 	public void diffItemExamples(List<JsonNode> original, List<JsonNode> updated) {
 	}
 
-	public boolean diffItemDefaultValue(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
-		return true;
+	public void diffItemDefaultValue(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
 	}
 
 	public void afterDiffItemDefaultValue(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
@@ -166,8 +162,7 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 	public void diffItemDeprecated(Boolean original, Boolean updated) {
 	}
 
-	public boolean visitSchema(Syn2Schema original, Syn2Schema updated) {
-		return true;
+	public void visitSchema(Syn2Schema original, Syn2Schema updated) {
 	}
 
 	public void afterVisitSchema(Syn2Schema original, Syn2Schema updated) {
@@ -179,8 +174,7 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 	public void diffSchemaType(String original, String updated) {
 	}
 
-	public boolean diffSchemaItems(BooleanSchemaSchemaListUnion original, BooleanSchemaSchemaListUnion updated) {
-		return true;
+	public void diffSchemaItems(BooleanSchemaSchemaListUnion original, BooleanSchemaSchemaListUnion updated) {
 	}
 
 	public void afterDiffSchemaItems(BooleanSchemaSchemaListUnion original, BooleanSchemaSchemaListUnion updated) {
@@ -190,8 +184,7 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 			CollectionDiff<P, BooleanSchemaUnion> diff) {
 	}
 
-	public boolean visitSchemaProperty(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
-		return true;
+	public void visitSchemaProperty(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
 	}
 
 	public void afterVisitSchemaProperty(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
@@ -201,8 +194,7 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 			CollectionDiff<P, BooleanSchemaUnion> diff) {
 	}
 
-	public boolean visitSchemaAllOfItem(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
-		return true;
+	public void visitSchemaAllOfItem(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
 	}
 
 	public void afterVisitSchemaAllOfItem(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
@@ -212,8 +204,7 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 			CollectionDiff<P, BooleanSchemaUnion> diff) {
 	}
 
-	public boolean visitSchemaDefinition(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
-		return true;
+	public void visitSchemaDefinition(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
 	}
 
 	public void afterVisitSchemaDefinition(BooleanSchemaUnion original, BooleanSchemaUnion updated) {
@@ -223,8 +214,7 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 			CollectionDiff<P, SchemaOrBoolean> diff) {
 	}
 
-	public boolean visitSchemaNestedSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
-		return true;
+	public void visitSchemaNestedSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
 	}
 
 	public void afterVisitSchemaNestedSchema(SchemaOrBoolean original, SchemaOrBoolean updated) {
@@ -234,8 +224,7 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 			CollectionDiff<P, SchemaOrBoolean> diff) {
 	}
 
-	public boolean visitSchemaComposedSchemasItem(SchemaOrBoolean original, SchemaOrBoolean updated) {
-		return true;
+	public void visitSchemaComposedSchemasItem(SchemaOrBoolean original, SchemaOrBoolean updated) {
 	}
 
 	public void afterVisitSchemaComposedSchemasItem(SchemaOrBoolean original, SchemaOrBoolean updated) {
@@ -250,15 +239,13 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 	public void diffSchemaEnum(List<JsonNode> original, List<JsonNode> updated) {
 	}
 
-	public boolean visitPaths(Syn2Paths original, Syn2Paths updated) {
-		return true;
+	public void visitPaths(Syn2Paths original, Syn2Paths updated) {
 	}
 
 	public void afterVisitPaths(Syn2Paths original, Syn2Paths updated) {
 	}
 
-	public boolean visitPathItem(Syn2PathItem original, Syn2PathItem updated) {
-		return true;
+	public void visitPathItem(Syn2PathItem original, Syn2PathItem updated) {
 	}
 
 	public void afterVisitPathItem(Syn2PathItem original, Syn2PathItem updated) {
@@ -270,36 +257,31 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 	public void diffPathItemSummary(String original, String updated) {
 	}
 
-	public boolean diffPathItemGet(SynOperation original, SynOperation updated) {
-		return true;
+	public void diffPathItemGet(SynOperation original, SynOperation updated) {
 	}
 
 	public void afterDiffPathItemGet(SynOperation original, SynOperation updated) {
 	}
 
-	public boolean diffPathItemPut(SynOperation original, SynOperation updated) {
-		return true;
+	public void diffPathItemPut(SynOperation original, SynOperation updated) {
 	}
 
 	public void afterDiffPathItemPut(SynOperation original, SynOperation updated) {
 	}
 
-	public boolean diffPathItemPost(SynOperation original, SynOperation updated) {
-		return true;
+	public void diffPathItemPost(SynOperation original, SynOperation updated) {
 	}
 
 	public void afterDiffPathItemPost(SynOperation original, SynOperation updated) {
 	}
 
-	public boolean diffPathItemDelete(Syn2Operation original, Syn2Operation updated) {
-		return true;
+	public void diffPathItemDelete(Syn2Operation original, Syn2Operation updated) {
 	}
 
 	public void afterDiffPathItemDelete(Syn2Operation original, Syn2Operation updated) {
 	}
 
-	public boolean visitOperation(Syn2Operation original, Syn2Operation updated) {
-		return true;
+	public void visitOperation(Syn2Operation original, Syn2Operation updated) {
 	}
 
 	public void afterVisitOperation(Syn2Operation original, Syn2Operation updated) {
@@ -318,8 +300,7 @@ public abstract class Syn2DiffVisitor<P extends PairingKey> {
 			CollectionDiff<P, SynItem> diff) {
 	}
 
-	public boolean visitOperationParametersItem(SynItem original, SynItem updated) {
-		return true;
+	public void visitOperationParametersItem(SynItem original, SynItem updated) {
 	}
 
 	public void afterVisitOperationParametersItem(SynItem original, SynItem updated) {


### PR DESCRIPTION
## Summary
Unify regular and diff visitor traversal control: all visit/diff methods are now void. Visitors call `traversalContext.skip()` to prevent auto-recursion.

### Changes
- **TraversalAction** enum (CONTINUE, SKIP) + `TraversalContext.skip()`
- **DiffVisitor**: boolean visit/diff methods → void, protected `traversalContext` field
- **DiffTraverser**: resetAction/consumeAction around each visitor call, sets context on visitor
- **CompoundSchemaDiffVisitor**: 22 boolean methods → void, `return false` → `traversalContext.skip()`
- Regular traverser already updated in previous commit (G13c/C41n)

### Design
Both regular and diff visitors now use the same pattern:
```java
void visitFullSchema(original, updated) {
    // do work...
    traversalContext.skip(); // prevent auto-recursion
}
```

Extensible: future actions (REPLACE for tree mutation) can be added to TraversalAction without changing method signatures.

## Context
G13d — completes the unified traversal design started in G13c.

## Test plan
- [x] All 1147 tests pass
- [x] Snapshots regenerated