### PR TITLE
feat(compat): curated --explain-style help for DiffType (C42c)

### DIFF
--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/DiffType.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/DiffType.java
@@ -1,5 +1,7 @@
 package io.apitomy.datamodels.jsonschema.compat;
 
+import java.util.Optional;
+
 /**
  * Classifies a single difference found between two schemas.
  * <p>
@@ -245,5 +247,18 @@ public enum DiffType {
      */
     public String getShortDescription() {
         return shortDescription;
+    }
+
+    /**
+     * A curated, long-form explanation of this kind of difference, formatted as Markdown.
+     * <p>
+     * Unlike {@link #getShortDescription()}, help text is optional: only a curated subset of diff
+     * types carry one, so this returns {@link Optional#empty()} for the rest. The text is loaded
+     * lazily from a bundled manifest on first access and cached for the lifetime of the JVM.
+     *
+     * @return the help text, or {@link Optional#empty()} if none is curated for this constant
+     */
+    public Optional<String> getHelp() {
+        return DiffTypeHelp.get(name());
     }
 }

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/DiffTypeHelp.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/DiffTypeHelp.java
@@ -1,0 +1,94 @@
+package io.apitomy.datamodels.jsonschema.compat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Lazily-loaded, cached store of long-form, {@code --explain}-style help text for {@link DiffType}
+ * constants.
+ *
+ * <p>Help text is optional and curated: only a subset of diff types carry an entry. The manifest
+ * lives at {@code difftype-help.json} beside this class and uses the envelope
+ * {@code {"version":1,"help":{"<DiffType name>":[<markdown lines>]}}}, where each value is an array
+ * of Markdown lines joined with {@code \n}.
+ *
+ * <p>This class is deliberately kept separate from the {@link DiffType} enum so the enum stays free
+ * of Jackson and resource-loading concerns. The map is built once, on first access, and cached.
+ * Access is guarded by {@code synchronized} — help lookups are rare (only when a caller asks for it),
+ * so the coarse lock costs nothing in practice.
+ */
+final class DiffTypeHelp {
+
+    private static final String RESOURCE = "difftype-help.json";
+
+    private static Map<String, String> help;
+
+    private DiffTypeHelp() {
+    }
+
+    /**
+     * Returns the curated help text for the given diff-type name, if one exists.
+     *
+     * @param diffTypeName the {@link DiffType#name()} of the constant
+     * @return the joined Markdown help, or {@link Optional#empty()} if none is curated
+     */
+    static synchronized Optional<String> get(String diffTypeName) {
+        if (help == null) {
+            help = load();
+        }
+        return Optional.ofNullable(help.get(diffTypeName));
+    }
+
+    private static Map<String, String> load() {
+        var mapper = new ObjectMapper();
+        try (InputStream in = DiffTypeHelp.class.getResourceAsStream(RESOURCE)) {
+            if (in == null) {
+                throw new IllegalStateException("Missing help manifest resource: " + RESOURCE);
+            }
+            JsonNode root = mapper.readTree(in);
+            JsonNode helpNode = root.get("help");
+            if (helpNode == null || !helpNode.isObject()) {
+                throw new IllegalStateException(
+                        "Help manifest is missing a 'help' object: " + RESOURCE);
+            }
+            Map<String, String> result = new LinkedHashMap<>();
+            var fields = helpNode.fields();
+            while (fields.hasNext()) {
+                var entry = fields.next();
+                String name = entry.getKey();
+                // Fail fast on typos: every key must name a real DiffType constant.
+                DiffType.valueOf(name);
+                result.put(name, joinLines(name, entry.getValue()));
+            }
+            return Collections.unmodifiableMap(result);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read help manifest: " + RESOURCE, e);
+        }
+    }
+
+    private static String joinLines(String name, JsonNode value) {
+        if (value.isTextual()) {
+            return value.asText();
+        }
+        if (!value.isArray()) {
+            throw new IllegalStateException(
+                    "Help entry '" + name + "' must be a string or array of strings, was: "
+                            + value.getNodeType());
+        }
+        var sb = new StringBuilder();
+        for (int i = 0; i < value.size(); i++) {
+            if (i > 0) {
+                sb.append('\n');
+            }
+            sb.append(value.get(i).asText());
+        }
+        return sb.toString();
+    }
+}

--- a/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/Difference.java
+++ b/data-models/src/main/java/io/apitomy/datamodels/jsonschema/compat/Difference.java
@@ -1,6 +1,7 @@
 package io.apitomy.datamodels.jsonschema.compat;
 
 import java.util.Objects;
+import java.util.Optional;
 
 public final class Difference {
 
@@ -21,6 +22,25 @@ public final class Difference {
 
     public DiffType getDiffType() {
         return diffType;
+    }
+
+    /**
+     * A human-readable one-line description of this difference. Delegates to
+     * {@link DiffType#getShortDescription()}.
+     */
+    public String getShortDescription() {
+        return diffType.getShortDescription();
+    }
+
+    /**
+     * A long-form, {@code --explain}-style explanation of this difference, if one is curated for
+     * its {@link DiffType}. Delegates to {@link DiffType#getHelp()}.
+     * <p>
+     * This accessor lives on {@code Difference} (not only {@code DiffType}) so that future help can
+     * be enriched with the concrete paths and sub-schemas carried by this instance.
+     */
+    public Optional<String> getHelp() {
+        return diffType.getHelp();
     }
 
     public String getPathOriginal() {

--- a/data-models/src/main/resources/io/apitomy/datamodels/jsonschema/compat/difftype-help.json
+++ b/data-models/src/main/resources/io/apitomy/datamodels/jsonschema/compat/difftype-help.json
@@ -1,0 +1,110 @@
+{
+  "version": 1,
+  "help": {
+    "OBJECT_TYPE_PROPERTY_SCHEMAS_EXTENDED": [
+      "The set of objects accepted by `properties` was widened.",
+      "",
+      "This is reported, for example, when a named property is added while the old schema forbade unknown properties (`additionalProperties: false`), or when a named property is removed while the new schema still accepts it via `additionalProperties`. In both cases the object accepts at least everything it accepted before.",
+      "",
+      "Backward compatible: a reader using the new schema accepts all data written with the old schema. The forward direction is not guaranteed — old readers may reject data that exploits the widening."
+    ],
+    "OBJECT_TYPE_PROPERTY_SCHEMAS_NARROWED": [
+      "The set of objects accepted by `properties` was narrowed, so some data valid under the old schema is rejected by the new one.",
+      "",
+      "A common and surprising cause is *adding* a property definition when the schema otherwise accepted any value for that name (`additionalProperties` absent or `true`): the name that used to accept anything is now constrained by the new property schema. Removing a property while unknown properties are forbidden narrows the object as well.",
+      "",
+      "Not backward compatible: a reader using the new schema may reject data written with the old schema. Note that adding a property is therefore not automatically a safe change."
+    ],
+    "OBJECT_TYPE_PROPERTY_SCHEMAS_NARROWED_COMPATIBLE_WITH_ADDITIONAL_PROPERTIES": [
+      "A property was added, and the addition is safe because the old schema already validated unknown properties through an `additionalProperties` schema, and the newly-added property's schema is compatible with that `additionalProperties` schema.",
+      "",
+      "Because the property name was already constrained (by `additionalProperties`) under the old schema and the new, more specific constraint is no stricter, no previously-valid data is rejected.",
+      "",
+      "Backward compatible. This is the case that distinguishes a safe property addition from the narrowing reported by `OBJECT_TYPE_PROPERTY_SCHEMAS_NARROWED`."
+    ],
+    "OBJECT_TYPE_ADDITIONAL_PROPERTIES_TRUE_TO_FALSE": [
+      "`additionalProperties` changed from allowing extra properties to forbidding them (`false`).",
+      "",
+      "Objects that carried properties not named in `properties` were valid before and are rejected now.",
+      "",
+      "Not backward compatible: a reader using the new schema rejects such previously-valid data."
+    ],
+    "OBJECT_TYPE_ADDITIONAL_PROPERTIES_SCHEMA_ADDED": [
+      "A schema constraint for `additionalProperties` was introduced where extra properties were previously unconstrained.",
+      "",
+      "Extra properties that were accepted with any value before must now satisfy the added schema, so some previously-valid data is rejected.",
+      "",
+      "Not backward compatible."
+    ],
+    "OBJECT_TYPE_REQUIRED_PROPERTIES_MEMBER_ADDED": [
+      "A property was added to `required`.",
+      "",
+      "Instances that omitted this property were valid under the old schema and are invalid under the new one.",
+      "",
+      "Not backward compatible: a reader using the new schema rejects old data that lacks the newly-required property. Adding a required property is one of the most common breaking changes."
+    ],
+    "OBJECT_TYPE_REQUIRED_PROPERTIES_MEMBER_REMOVED": [
+      "A property was removed from `required`; it became optional.",
+      "",
+      "Every instance valid under the old schema still carried the property, so it remains valid under the new schema, which merely no longer demands it.",
+      "",
+      "Backward compatible. The forward direction does not hold: old readers may reject new data that omits the now-optional property."
+    ],
+    "SUBSCHEMA_TYPE_CHANGED": [
+      "The declared `type` was changed to a different, non-overlapping type (for example `string` to `integer`).",
+      "",
+      "Instances of the old type are not instances of the new type, so data written with the old schema is rejected.",
+      "",
+      "Not backward compatible. Broadening `type` — removing it or changing it to a superset of the old one — is reported separately and can be compatible."
+    ],
+    "NUMBER_TYPE_INTEGER_REQUIRED_FALSE_TO_TRUE": [
+      "The numeric type was restricted from `number` to `integer`.",
+      "",
+      "Non-integer numbers such as `1.5` were valid before and are rejected now.",
+      "",
+      "Not backward compatible: a reader using the new schema rejects fractional values that the old schema accepted."
+    ],
+    "ENUM_TYPE_VALUES_MEMBER_ADDED": [
+      "A value was added to the `enum` allowed set, widening it.",
+      "",
+      "Every value valid under the old `enum` is still a member of the new, larger set.",
+      "",
+      "Backward compatible. The forward direction does not hold: old readers reject the newly-added value."
+    ],
+    "ENUM_TYPE_VALUES_MEMBER_REMOVED": [
+      "A value was removed from the `enum` allowed set, narrowing it.",
+      "",
+      "Data using the removed value was valid before and is rejected now.",
+      "",
+      "Not backward compatible: a reader using the new schema rejects old data that used the removed value."
+    ],
+    "CONST_TYPE_VALUE_CHANGED": [
+      "The single value fixed by `const` was changed.",
+      "",
+      "Only the old constant was valid before, and only the new constant is valid now, so any data written with the old schema is rejected.",
+      "",
+      "Not backward compatible."
+    ],
+    "CONDITIONAL_TYPE_IF_SCHEMA_ADDED": [
+      "An `if` subschema was introduced where there was none.",
+      "",
+      "Conditional (`if`/`then`/`else`) validation applies only when an `if` is present. Adding one activates a `then`/`else` branch that can reject instances the old schema accepted.",
+      "",
+      "Because the effect depends entirely on the accompanying `then`/`else` branches, this is flagged conservatively as not backward compatible."
+    ],
+    "CONDITIONAL_TYPE_THEN_SCHEMA_COMPATIBLE_FORWARD_NOT_BACKWARD": [
+      "The `then` branch of a conditional changed so that it is compatible in the forward direction only.",
+      "",
+      "The `then` branch applies to instances that match `if`. It was tightened, so some instances that matched `if` and were valid under the old `then` are rejected under the new one.",
+      "",
+      "Not backward compatible (forward-only): a reader using the new schema may reject old data, even though old readers accept all new data."
+    ],
+    "CONDITIONAL_TYPE_ELSE_SCHEMA_COMPATIBLE_BACKWARD_NOT_FORWARD": [
+      "The `else` branch of a conditional changed so that it is compatible in the backward direction only.",
+      "",
+      "The `else` branch applies to instances that do not match `if`. The new branch still accepts everything the old one did, but it also accepts data the old branch rejected.",
+      "",
+      "Backward compatible: a reader using the new schema accepts all old data. The forward direction fails — old readers may reject the newly-accepted data."
+    ]
+  }
+}

--- a/data-models/src/test/java/io/apitomy/datamodels/jsonschema/compat/DiffTypeHelpTest.java
+++ b/data-models/src/test/java/io/apitomy/datamodels/jsonschema/compat/DiffTypeHelpTest.java
@@ -1,0 +1,87 @@
+package io.apitomy.datamodels.jsonschema.compat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+
+public class DiffTypeHelpTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String RESOURCE = "difftype-help.json";
+
+    private JsonNode readManifest() throws IOException {
+        try (InputStream in = DiffType.class.getResourceAsStream(RESOURCE)) {
+            Assertions.assertNotNull(in, "help manifest resource must exist: " + RESOURCE);
+            return MAPPER.readTree(in);
+        }
+    }
+
+    @Test
+    public void manifestHasExpectedEnvelope() throws IOException {
+        JsonNode root = readManifest();
+        Assertions.assertEquals(1, root.path("version").asInt(-1),
+                "manifest 'version' must be 1");
+        Assertions.assertTrue(root.path("help").isObject(),
+                "manifest must contain a 'help' object");
+        Assertions.assertTrue(root.get("help").size() > 0,
+                "manifest 'help' object must not be empty");
+    }
+
+    @Test
+    public void everyKeyIsAValidDiffTypeName() throws IOException {
+        JsonNode help = readManifest().get("help");
+        var names = help.fieldNames();
+        while (names.hasNext()) {
+            String name = names.next();
+            // Throws IllegalArgumentException if the key is not a real DiffType constant.
+            Assertions.assertDoesNotThrow(() -> DiffType.valueOf(name),
+                    "help key must name a real DiffType constant: " + name);
+        }
+    }
+
+    @Test
+    public void everyManifestKeyResolvesToNonBlankHelp() throws IOException {
+        JsonNode help = readManifest().get("help");
+        var names = help.fieldNames();
+        while (names.hasNext()) {
+            DiffType type = DiffType.valueOf(names.next());
+            Optional<String> text = type.getHelp();
+            Assertions.assertTrue(text.isPresent(),
+                    "curated type must return help: " + type);
+            Assertions.assertFalse(text.get().isBlank(),
+                    "help text must not be blank: " + type);
+        }
+    }
+
+    @Test
+    public void curatedConstantsReturnHelp() {
+        // A representative curated entry, including the subtle additionalProperties-interaction case.
+        Assertions.assertTrue(
+                DiffType.OBJECT_TYPE_REQUIRED_PROPERTIES_MEMBER_ADDED.getHelp().isPresent());
+        Assertions.assertTrue(
+                DiffType.OBJECT_TYPE_PROPERTY_SCHEMAS_NARROWED_COMPATIBLE_WITH_ADDITIONAL_PROPERTIES
+                        .getHelp().isPresent());
+        Assertions.assertTrue(DiffType.CONST_TYPE_VALUE_CHANGED.getHelp().isPresent());
+    }
+
+    @Test
+    public void nonCuratedConstantReturnsEmpty() {
+        // A real, emitted diff type that is intentionally not part of the curated help set.
+        Assertions.assertTrue(
+                DiffType.OBJECT_TYPE_REQUIRED_PROPERTIES_REMOVED.getHelp().isEmpty());
+    }
+
+    @Test
+    public void differenceDelegatesToDiffType() {
+        DiffType type = DiffType.OBJECT_TYPE_REQUIRED_PROPERTIES_MEMBER_ADDED;
+        Difference diff = new Difference(type, "#/foo", "#/foo", "{}", "{}");
+        Assertions.assertEquals(type.getShortDescription(), diff.getShortDescription());
+        Assertions.assertEquals(type.getHelp(), diff.getHelp());
+        Assertions.assertTrue(diff.getHelp().isPresent());
+    }
+}


### PR DESCRIPTION
Adds optional long-form, `--explain`-style help text for diff types, complementing the one-line short descriptions from C42b (#1191).

## What's in it

- **Manifest** `difftype-help.json` — envelope `{"version":1,"help":{"<DiffType name>":[<markdown lines>]}}`, each entry an array of Markdown lines joined with `\n`. 16 curated entries covering the most common and most subtle compatibility cases.
- **`DiffTypeHelp`** — a lazily-loaded, `synchronized` cache. Keeps Jackson and resource loading out of the `DiffType` enum, and fails fast at load time if a manifest key is not a real `DiffType` constant or an entry is malformed.
- **`DiffType.getHelp(): Optional<String>`** — delegates to `DiffTypeHelp`. Help is optional; only curated constants return a value.
- **`Difference.getShortDescription()` / `Difference.getHelp()`** — delegate to the `DiffType`. `getHelp()` on `Difference` is the seam for future enrichment of help text with the concrete paths and sub-schemas carried by an instance.
- **`DiffTypeHelpTest`** — verifies the envelope, that every manifest key names a real `DiffType`, that curated constants return non-blank help, that a non-curated constant returns empty, and that `Difference` delegates.

## Notes

- Help prose uses a single direction convention throughout: *backward = a reader on the new schema accepts all data written with the old schema; forward = old readers accept new data* — matching `checkBackward(original, updated)` and the forward-swap in the checker.
- The curated set targets only diff types the visitor actually emits. In particular it uses the real property-schema codes (`..._EXTENDED`, `..._NARROWED`, `..._NARROWED_COMPATIBLE_WITH_ADDITIONAL_PROPERTIES`) rather than the never-emitted `..._MEMBER_ADDED/_REMOVED` constants (which are slated for removal in C42g). The `NARROWED` vs `NARROWED_COMPATIBLE_WITH_ADDITIONAL_PROPERTIES` pair captures the subtle "adding a property narrows the object unless `additionalProperties` already covered it" case.

## Testing

```
JAVA_HOME=/usr/lib/jvm/temurin-21-jdk mvn test -pl data-models -am \
  -Dtest=DiffTypeHelpTest,JsonSchemaCompatibilityTest -Dsurefire.failIfNoSpecifiedTests=false
```

`DiffTypeHelpTest` 6/6; `JsonSchemaCompatibilityTest` 9/9 (unchanged).