### PR TITLE
ci(release): backport release-workflow changes to 3.1.x

### DIFF
--- a/.github/scripts/compute-release-versions.sh
+++ b/.github/scripts/compute-release-versions.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# Decides which version gets released and which version the branch moves to
+# afterwards.
+#
+# Usage: compute-release-versions.sh <current-version> [next-snapshot-version]
+#
+# Writes `key=value` lines to stdout, in the form the release workflow appends
+# to $GITHUB_OUTPUT:
+#
+#   release-version=...    the version to publish
+#   snapshot-version=...   the version the branch is set to afterwards
+#   prerelease=true|false  whether the release is a pre-release
+#
+# Diagnostics go to stderr, so stdout stays safe to redirect into $GITHUB_OUTPUT.
+#
+# The POM is the single source of truth for what gets released: the release
+# version is the current version with -SNAPSHOT stripped. Only the next
+# snapshot needs a rule, and it depends on whether the release is a
+# pre-release:
+#
+#   4.0.0-beta.1-SNAPSHOT -> release 4.0.0-beta.1, next 4.0.0-beta.2-SNAPSHOT
+#   4.0.0-SNAPSHOT        -> release 4.0.0,        next 4.0.1-SNAPSHOT
+#   3.1.4-SNAPSHOT        -> release 3.1.4,        next 3.1.5-SNAPSHOT
+#
+# That always continues the current line, which is right for routine releases
+# but never moves between lines. Ending a beta line, or opening a new minor or
+# major, is exactly that move -- hence the optional override.
+#
+set -euo pipefail
+
+CURRENT_VERSION="${1:-}"
+NEXT_SNAPSHOT_INPUT="${2:-}"
+
+if [[ -z "$CURRENT_VERSION" ]]; then
+  echo "::error::No current version given (expected the project version as \$1)." >&2
+  exit 1
+fi
+
+RELEASE_VERSION="${CURRENT_VERSION%-SNAPSHOT}"
+
+if [[ "$RELEASE_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)-(alpha|beta|rc)\.([0-9]+)$ ]]; then
+  SNAPSHOT_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}-${BASH_REMATCH[4]}.$((BASH_REMATCH[5] + 1))-SNAPSHOT"
+  PRERELEASE=true
+elif [[ "$RELEASE_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+  SNAPSHOT_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$((BASH_REMATCH[3] + 1))-SNAPSHOT"
+  PRERELEASE=false
+else
+  echo "::error::Cannot compute a release from project version '$CURRENT_VERSION'." >&2
+  echo "::error::Expected MAJOR.MINOR.PATCH[-(alpha|beta|rc).N]-SNAPSHOT." >&2
+  exit 1
+fi
+
+# An explicit next development version wins over the computed one. It is
+# validated to the same shape the computation produces, because the value is
+# committed straight back to the release branch. Whitespace is stripped first,
+# since it is typed into a web form.
+NEXT_SNAPSHOT_INPUT="${NEXT_SNAPSHOT_INPUT//[[:space:]]/}"
+if [[ -n "$NEXT_SNAPSHOT_INPUT" ]]; then
+  if [[ ! "$NEXT_SNAPSHOT_INPUT" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?-SNAPSHOT$ ]]; then
+    echo "::error::Invalid next-snapshot-version '$NEXT_SNAPSHOT_INPUT'." >&2
+    echo "::error::Expected MAJOR.MINOR.PATCH[-(alpha|beta|rc).N]-SNAPSHOT." >&2
+    exit 1
+  fi
+  if [[ "$NEXT_SNAPSHOT_INPUT" == "$CURRENT_VERSION" ]]; then
+    echo "::error::next-snapshot-version '$NEXT_SNAPSHOT_INPUT' is the version being released from." >&2
+    echo "::error::The branch would stay on it and the next release would repeat $RELEASE_VERSION." >&2
+    exit 1
+  fi
+  echo "Overriding computed next snapshot $SNAPSHOT_VERSION with $NEXT_SNAPSHOT_INPUT" >&2
+  SNAPSHOT_VERSION="$NEXT_SNAPSHOT_INPUT"
+fi
+
+echo "Release version: $RELEASE_VERSION (prerelease: $PRERELEASE)" >&2
+echo "Next snapshot version: $SNAPSHOT_VERSION" >&2
+
+echo "release-version=$RELEASE_VERSION"
+echo "snapshot-version=$SNAPSHOT_VERSION"
+echo "prerelease=$PRERELEASE"

--- a/.github/scripts/compute-release-versions.test.sh
+++ b/.github/scripts/compute-release-versions.test.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# Tests for compute-release-versions.sh.
+#
+# This logic decides what gets published to Maven Central and NPM, and it
+# cannot be exercised without cutting a real release -- so it is covered here
+# instead. Run it directly:
+#
+#   ./.github/scripts/compute-release-versions.test.sh
+#
+set -uo pipefail
+
+SCRIPT="$(dirname "$0")/compute-release-versions.sh"
+failures=0
+
+# Runs the real script and flattens its stdout to a single comparable line.
+# A non-zero exit becomes "REJECTED", so the error cases assert that the
+# release is refused rather than computed wrongly.
+run() {
+  local out
+  if ! out=$("$SCRIPT" "$1" "${2:-}" 2>/dev/null); then
+    echo "REJECTED"
+    return
+  fi
+  # release-version=X\nsnapshot-version=Y\nprerelease=Z  ->  "X | Y | Z"
+  echo "$out" | cut -d= -f2- | paste -sd'|' - | sed 's/|/ | /g'
+}
+
+check() { # <current-version> <next-snapshot-override> <expected>
+  local got label
+  got=$(run "$1" "$2")
+  label="$1${2:+  +override=[$2]}"   # brackets make stray whitespace visible
+  if [[ "$got" == "$3" ]]; then
+    printf '  ok   %-52s -> %s\n' "$label" "$got"
+  else
+    printf '  FAIL %-52s -> %s\n       expected: %s\n' "$label" "$got" "$3"
+    failures=$((failures + 1))
+  fi
+}
+
+echo "The beta line advances itself:"
+check "4.0.0-beta.1-SNAPSHOT" "" "4.0.0-beta.1 | 4.0.0-beta.2-SNAPSHOT | true"
+check "4.0.0-beta.2-SNAPSHOT" "" "4.0.0-beta.2 | 4.0.0-beta.3-SNAPSHOT | true"
+check "4.0.0-beta.9-SNAPSHOT" "" "4.0.0-beta.9 | 4.0.0-beta.10-SNAPSHOT | true"
+
+echo "GA and the maintenance line bump the patch:"
+check "4.0.0-SNAPSHOT" "" "4.0.0 | 4.0.1-SNAPSHOT | false"
+check "3.1.4-SNAPSHOT" "" "3.1.4 | 3.1.5-SNAPSHOT | false"
+check "3.1.9-SNAPSHOT" "" "3.1.9 | 3.1.10-SNAPSHOT | false"
+
+echo "alpha and rc follow the same rule as beta:"
+check "4.1.0-rc.1-SNAPSHOT" "" "4.1.0-rc.1 | 4.1.0-rc.2-SNAPSHOT | true"
+check "5.0.0-alpha.3-SNAPSHOT" "" "5.0.0-alpha.3 | 5.0.0-alpha.4-SNAPSHOT | true"
+
+echo "The override moves between lines -- ending the beta line:"
+# The release itself is still a prerelease; the NEXT one is 4.0.0 GA.
+check "4.0.0-beta.3-SNAPSHOT" "4.0.0-SNAPSHOT" "4.0.0-beta.3 | 4.0.0-SNAPSHOT | true"
+check "4.0.0-beta.2-SNAPSHOT" "4.0.0-rc.1-SNAPSHOT" "4.0.0-beta.2 | 4.0.0-rc.1-SNAPSHOT | true"
+check "4.0.0-SNAPSHOT" "4.1.0-SNAPSHOT" "4.0.0 | 4.1.0-SNAPSHOT | false"
+check "3.1.4-SNAPSHOT" "3.2.0-SNAPSHOT" "3.1.4 | 3.2.0-SNAPSHOT | false"
+
+echo "Whitespace from the web form is stripped, not rejected:"
+TRAILING_SPACE="4.0.0-SNAPSHOT "   # deliberate trailing space
+check "4.0.0-beta.1-SNAPSHOT" "$TRAILING_SPACE" "4.0.0-beta.1 | 4.0.0-SNAPSHOT | true"
+
+echo "A malformed project version fails the release rather than mis-computing it:"
+check "4.0.0-beta-SNAPSHOT" "" "REJECTED"
+check "4.0.0.1-SNAPSHOT" "" "REJECTED"
+check "4.0-SNAPSHOT" "" "REJECTED"
+check "not-a-version" "" "REJECTED"
+check "4.0.0-beta.x-SNAPSHOT" "" "REJECTED"
+
+echo "So does a malformed override -- it is committed back to the branch:"
+check "4.0.0-beta.1-SNAPSHOT" "4.0.0" "REJECTED"
+check "4.0.0-beta.1-SNAPSHOT" "v4.0.0-SNAPSHOT" "REJECTED"
+check "4.0.0-beta.1-SNAPSHOT" "4.0-SNAPSHOT" "REJECTED"
+check "4.0.0-beta.1-SNAPSHOT" "4.0.0-beta-SNAPSHOT" "REJECTED"
+
+echo "An override equal to the current version would repeat the release forever:"
+check "4.0.0-beta.1-SNAPSHOT" "4.0.0-beta.1-SNAPSHOT" "REJECTED"
+
+echo
+if [[ $failures -eq 0 ]]; then
+  echo "ALL PASS"
+else
+  echo "$failures FAILURE(S)"
+  exit 1
+fi

--- a/.github/scripts/create-github-release.sh
+++ b/.github/scripts/create-github-release.sh
@@ -3,10 +3,27 @@ set -euxo pipefail
 
 RELEASE_VERSION="$1"
 BRANCH="$2"
+PRERELEASE="${3:-false}"
 
-echo "Creating github release '$RELEASE_VERSION' for Repo '$GITHUB_REPOSITORY' and Branch: '$BRANCH'"
+# Two things hang off these flags:
+#
+#  - A pre-release must be marked as one. Otherwise GitHub fires the "released"
+#    event, which update-website.yaml listens for, and a beta would bump the
+#    public website. Prereleases fire "prereleased" instead.
+#  - "Latest" is only meaningful for a GA release cut from the default branch.
+#    A patch released from a maintenance branch is newer by date but older by
+#    version, so it must not steal the Latest badge from the main line.
+EXTRA_ARGS=()
+if [[ "$PRERELEASE" == "true" ]]; then
+  EXTRA_ARGS+=(--prerelease --latest=false)
+elif [[ "$BRANCH" != "main" ]]; then
+  EXTRA_ARGS+=(--latest=false)
+fi
+
+echo "Creating github release '$RELEASE_VERSION' for Repo '$GITHUB_REPOSITORY' and Branch: '$BRANCH' (prerelease: $PRERELEASE)"
 gh release create "$RELEASE_VERSION" \
   --target "$BRANCH" \
   --title "$RELEASE_VERSION" \
-  --generate-notes
+  --generate-notes \
+  "${EXTRA_ARGS[@]}"
 echo "Github Release Created Successfully"

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -9,6 +9,11 @@ on:
         description: 'Branch/tag to publish from'
         required: true
         default: 'main'
+      prerelease:
+        description: 'Publish under the "beta" dist-tag instead of "latest"'
+        required: false
+        type: boolean
+        default: false
   workflow_call:
     inputs:
       release-version:
@@ -19,6 +24,11 @@ on:
         description: 'Branch/tag to publish from'
         required: true
         type: string
+      prerelease:
+        description: 'Publish under the "beta" dist-tag instead of "latest"'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   id-token: write
@@ -47,6 +57,7 @@ jobs:
         run: |
           echo "Publishing Apitomy Data Models version ${{ inputs.release-version }} to NPM"
           echo "Publishing from branch/tag: ${{ inputs.branch }}"
+          echo "NPM dist-tag: ${{ inputs.prerelease && 'beta' || 'latest' }}"
 
 
       - name: Code Checkout
@@ -67,10 +78,13 @@ jobs:
           MAVEN_OPTS: "-Dfile.encoding=UTF-8 --add-opens=java.base/java.net=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
 
 
+      # Pre-releases go under the "beta" dist-tag so that `npm i @apitomy/data-models`,
+      # which resolves "latest", keeps returning the newest GA release.
       - name: Publish to NPM
-        run: npm publish --provenance --access public ./data-models/target/ts/
+        run: npm publish --provenance --access public --tag "$NPM_DIST_TAG" ./data-models/target/ts/
         env:
           NODE_AUTH_TOKEN: ''
+          NPM_DIST_TAG: ${{ inputs.prerelease && 'beta' || 'latest' }}
 
 
       - name: Slack Notification (Always)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,10 @@ on:
         description: 'Branch to release from'
         required: false
         default: 'main'
+      next-snapshot-version:
+        description: 'Next development version (e.g. 4.0.0-SNAPSHOT to end the beta line). Leave empty to compute it.'
+        required: false
+        default: ''
 
 permissions:
   id-token: write
@@ -18,6 +22,7 @@ jobs:
     outputs:
       release-version: ${{ steps.versions.outputs.release-version }}
       snapshot-version: ${{ steps.versions.outputs.snapshot-version }}
+      prerelease: ${{ steps.versions.outputs.prerelease }}
     steps:
 
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
@@ -63,18 +68,16 @@ jobs:
 
       - name: Compute Release and Snapshot Versions
         id: versions
+        env:
+          # Read through the environment rather than interpolating the input
+          # directly into the script, so its contents can never be executed.
+          NEXT_SNAPSHOT_INPUT: ${{ inputs.next-snapshot-version }}
         run: |
+          # See .github/scripts/compute-release-versions.sh for the rules; it is
+          # covered by compute-release-versions.test.sh, since this decision
+          # cannot otherwise be exercised without cutting a real release.
           CURRENT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          RELEASE_VERSION="${CURRENT_VERSION%-SNAPSHOT}"
-          MAJOR=$(echo "$RELEASE_VERSION" | cut -d. -f1)
-          MINOR=$(echo "$RELEASE_VERSION" | cut -d. -f2)
-          PATCH=$(echo "$RELEASE_VERSION" | cut -d. -f3)
-          NEXT_PATCH=$((PATCH + 1))
-          SNAPSHOT_VERSION="${MAJOR}.${MINOR}.${NEXT_PATCH}-SNAPSHOT"
-          echo "release-version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "snapshot-version=$SNAPSHOT_VERSION" >> "$GITHUB_OUTPUT"
-          echo "Release version: $RELEASE_VERSION"
-          echo "Next snapshot version: $SNAPSHOT_VERSION"
+          ./.github/scripts/compute-release-versions.sh "$CURRENT_VERSION" "$NEXT_SNAPSHOT_INPUT" >> "$GITHUB_OUTPUT"
 
 
       - name: Update Release Version ${{ steps.versions.outputs.release-version }}
@@ -95,7 +98,7 @@ jobs:
 
 
       - name: Create GitHub Release
-        run: ./.github/scripts/create-github-release.sh ${{ steps.versions.outputs.release-version }} ${{ inputs.branch }}
+        run: ./.github/scripts/create-github-release.sh ${{ steps.versions.outputs.release-version }} ${{ inputs.branch }} ${{ steps.versions.outputs.prerelease }}
         env:
           GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
 
@@ -115,6 +118,7 @@ jobs:
     with:
       release-version: ${{ needs.release.outputs.release-version }}
       branch: ${{ inputs.branch }}
+      prerelease: ${{ needs.release.outputs.prerelease == 'true' }}
     secrets: inherit
 
 

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -33,6 +33,13 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
 
+      # Cheap, and it is the only coverage this logic can have: the release
+      # workflow's version computation cannot be exercised without cutting a
+      # real release.
+      - name: Test Release Version Computation
+        run: ./.github/scripts/compute-release-versions.test.sh
+
+
       - name: Build Project
         run: mvn clean install -Ptranspilation
         env:


### PR DESCRIPTION
Backports the release-workflow changes from #1203 to the maintenance line. **No version change** — `3.1.x` stays on `3.1.4-SNAPSHOT`.

Part of #1042 (C73b).

## Why this is required, not just tidy

Releasing 3.x is **broken** without it.

The release job checks out the branch being released into an empty workspace:

```yaml
git init
git remote add origin ...
git fetch
git checkout ${{ inputs.branch }}
```

So the *workflow YAML* comes from the ref the dispatch was launched from, but every *script on disk* comes from `inputs.branch`. Those two are different branches whenever `main` releases another line.

`main`'s `release.yaml` now calls `./.github/scripts/compute-release-versions.sh`. That script does not exist on `3.1.x`. Dispatching the release workflow from `main` with `branch: 3.1.x` therefore fails at the "Compute Release and Snapshot Versions" step, before publishing anything.

Dispatching from the `3.1.x` ref instead would have run the old workflow and succeeded — but with the pre-#1203 behaviour, including the bug where a `3.1.4` cut after `4.0.0` takes the **Latest** badge from the 4.0 line, because `create-github-release.sh` never passed `--latest=false`.

Either way, `3.1.x` needs these files.

## What changed

Straight cherry-pick of the CI commit from #1203, with the POM bump deliberately excluded. `verify.yaml`'s trigger list was already correct here (ca1fb1c3), so the only change to it is the added test step.

Behaviour on this branch is identical to before for a routine patch — verified by running the script against the actual branch version:

```
$ ./.github/scripts/compute-release-versions.sh 3.1.4-SNAPSHOT
release-version=3.1.4
snapshot-version=3.1.5-SNAPSHOT
prerelease=false
```

What it gains is the `--latest=false` guard for non-`main` releases, `--prerelease` support, the npm dist-tag plumbing, and the optional `next-snapshot-version` input (useful here for opening a `3.2.0` line).

## Testing

`compute-release-versions.test.sh` — 22 cases, all pass, and it now runs in this branch's verify build too. The 3.x cases are covered explicitly (`3.1.4 → 3.1.5-SNAPSHOT`, `3.1.9 → 3.1.10-SNAPSHOT`, and the `3.1.4 → 3.2.0-SNAPSHOT` override).
